### PR TITLE
Adding flux_error field to output spectra

### DIFF
--- a/trident/absorption_spectrum/absorption_spectrum.py
+++ b/trident/absorption_spectrum/absorption_spectrum.py
@@ -67,6 +67,7 @@ class AbsorptionSpectrum(object):
                                     float(n_lambda - 1), "angstrom")
         self.line_list = []
         self.continuum_list = []
+        self.snr = 100  # default signal to noise ratio for error estimation
 
     def add_line(self, label, field_name, wavelength,
                  f_value, gamma, atomic_mass,
@@ -195,6 +196,7 @@ class AbsorptionSpectrum(object):
            spectrum generation.
            Default: "auto"
         """
+        self.snr = 100
         if line_list_file is not None:
             mylog.info("'line_list_file' keyword is deprecated. Please use " \
                        "'output_absorbers_file'.")
@@ -696,7 +698,7 @@ class AbsorptionSpectrum(object):
         output.create_dataset('error', data=self._error_func(self.flux_field))
         output.close()
 
-    def _error_func(self, flux, sn=100):
+    def _error_func(self, flux):
         """
         Many observational analysis programs require a flux error channel
         in addition to a flux channel.  So we create a zeroth order 
@@ -704,7 +706,10 @@ class AbsorptionSpectrum(object):
         of the flux.  Unfortunately, with flux normalized to be < 1, this
         would result in errors larger than the flux values themselves,
         so we normalize by an arbitrary signal-to-noise ratio, which by default
-        is set to 100.  This assures our flux errors are smaller than our 
-        fluxes for most flux reasonable flux values.
+        is set to 100.  This yields a typical error for a normalized spectrum of
+        sqrt(1.0*100)/100 = 0.1.  This assures our flux errors are smaller 
+        than our fluxes for most flux reasonable flux values.  Note that 
+        when a signal to noise ratio is specified for adding gaussian noise,
+        it uses this updated value for estimating the errors.
         """
-        return np.sqrt(flux*sn)/sn
+        return np.sqrt(flux*self.snr)/self.snr

--- a/trident/absorption_spectrum/absorption_spectrum.py
+++ b/trident/absorption_spectrum/absorption_spectrum.py
@@ -662,7 +662,7 @@ class AbsorptionSpectrum(object):
         """
         mylog.info("Writing spectrum to ascii file: %s.", filename)
         f = open(filename, 'w')
-        f.write("# wavelength[A] tau flux error\n")
+        f.write("# wavelength[A] tau flux flux_error\n")
         for i in range(self.lambda_field.size):
             f.write("%e %e %e %e\n" % (self.lambda_field[i],
                                     self.tau_field[i], 
@@ -679,7 +679,7 @@ class AbsorptionSpectrum(object):
         col1 = pyfits.Column(name='wavelength', format='E', array=self.lambda_field)
         col2 = pyfits.Column(name='tau', format='E', array=self.tau_field)
         col3 = pyfits.Column(name='flux', format='E', array=self.flux_field)
-        col4 = pyfits.Column(name='error', format='E', array=self._error_func(self.flux_field))
+        col4 = pyfits.Column(name='flux_error', format='E', array=self._error_func(self.flux_field))
         cols = pyfits.ColDefs([col1, col2, col3, col4])
         tbhdu = pyfits.BinTableHDU.from_columns(cols)
         tbhdu.writeto(filename, clobber=True)
@@ -695,7 +695,7 @@ class AbsorptionSpectrum(object):
         output.create_dataset('wavelength', data=self.lambda_field)
         output.create_dataset('tau', data=self.tau_field)
         output.create_dataset('flux', data=self.flux_field)
-        output.create_dataset('error', data=self._error_func(self.flux_field))
+        output.create_dataset('flux_error', data=self._error_func(self.flux_field))
         output.close()
 
     def _error_func(self, flux):

--- a/trident/spectrum_generator.py
+++ b/trident/spectrum_generator.py
@@ -877,9 +877,9 @@ class SpectrumGenerator(AbsorptionSpectrum):
         >>> sg.plot_spectrum('temp.png')
         """
         if format is None:
-            if filename.endswith('.h5'):
+            if filename.endswith('.h5') or filename.endswith('hdf5'):
                 self._write_spectrum_hdf5(filename)
-            elif filename.endswith('.fits'):
+            elif filename.endswith('.fits') or filename.endswith('FITS'):
                 self._write_spectrum_fits(filename)
             else:
                 self._write_spectrum_ascii(filename)

--- a/trident/spectrum_generator.py
+++ b/trident/spectrum_generator.py
@@ -598,6 +598,7 @@ class SpectrumGenerator(AbsorptionSpectrum):
         >>> sg.add_gaussian_noise(10)
         >>> sg.plot_spectrum('spec_noise.png')
         """
+        self.snr = snr
         np.random.seed(seed)
         noise = np.random.normal(loc=0.0, scale=1/float(snr),
                                  size=self.flux_field.size)

--- a/trident/spectrum_generator.py
+++ b/trident/spectrum_generator.py
@@ -496,6 +496,9 @@ class SpectrumGenerator(AbsorptionSpectrum):
         MW_spectrum = self._get_milky_way_foreground(filename=filename)
         flux_field *= MW_spectrum
 
+        # Negative fluxes don't make sense, so clip
+        np.clip(flux_field, 0, np.inf, out=flux_field)
+
     def add_qso_spectrum(self, flux_field=None,
                          emitting_redshift=None,
                          observing_redshift=None,
@@ -558,6 +561,9 @@ class SpectrumGenerator(AbsorptionSpectrum):
                                               filename=filename)
         flux_field *= qso_spectrum
 
+        # Negative fluxes don't make sense, so clip
+        np.clip(flux_field, 0, np.inf, out=flux_field)
+
     def add_gaussian_noise(self, snr, seed=None):
         """
         Postprocess a spectrum to add gaussian random noise of a given SNR.
@@ -603,6 +609,9 @@ class SpectrumGenerator(AbsorptionSpectrum):
         noise = np.random.normal(loc=0.0, scale=1/float(snr),
                                  size=self.flux_field.size)
         self.add_noise_vector(noise)
+
+        # Negative fluxes don't make sense, so clip
+        np.clip(self.flux_field, 0, np.inf, out=self.flux_field)
 
     def add_noise_vector(self, noise):
         """
@@ -702,6 +711,9 @@ class SpectrumGenerator(AbsorptionSpectrum):
             lsf = LSF(function=function, width=width, filename=filename)
         from astropy.convolution import convolve
         self.flux_field = convolve(self.flux_field, lsf.kernel)
+
+        # Negative fluxes don't make sense, so clip
+        np.clip(self.flux_field, 0, np.inf, out=self.flux_field)
 
     def load_spectrum(self, lambda_field=None, tau_field=None, flux_field=None):
         """

--- a/trident/spectrum_generator.py
+++ b/trident/spectrum_generator.py
@@ -644,6 +644,7 @@ class SpectrumGenerator(AbsorptionSpectrum):
                 "Flux (%s) and noise (%s) vectors must have same shape." %
                 (self.flux_field.shape, noise.shape))
         self.flux_field += noise
+        self.snr = 1 / np.std(noise)
 
     def apply_lsf(self, function=None, width=None, filename=None):
         """


### PR DESCRIPTION
Observers are accustomed to having a flux_error field included along with the flux field in output spectra, and they have requested that we give some "dummy" flux_error field in our generated spectra.  I have added such a dummy field to be output for text, FITS, and HDF5 spectral outputs.  It behaves *roughly* like it should, but this is for the most part just a place holder for observers.

Since our normalized fluxes are usually in the range 0->1, I take a S/N value (estimated initially to be 100 for raw data), and calculate the flux error as:

sqrt(flux*SNR)/SNR

For a flux value of 1, this gives an error of 0.1 (ie 10% of the flux).  For a flux value of 0.5, it gives an error of 0.07 (14% of the flux), etc.  This also behaves roughly correctly when we post-process spectra to include MW foreground and quasar background with normalized flux values going above 1.  For a flux value of 2, this gives an error of 0.14 ( 7% of the flux).  

When the user specifies a SNR for adding gaussian noise, the flux_error will be calculated using this SNR instead of the default 100.

There are a few additional changes added here to assure that a post-processed flux value never goes negative, which could previously happen when adding MW foreground and quasar background.  Negative fluxes don't mean anything, so it makes sense to avoid them.