### PR TITLE
Replace particle_type keyword with sampling_type. (closes Issue #4 and #5)

### DIFF
--- a/trident/absorption_spectrum/absorption_spectrum.py
+++ b/trident/absorption_spectrum/absorption_spectrum.py
@@ -677,7 +677,7 @@ class AbsorptionSpectrum(object):
         col3 = pyfits.Column(name='flux', format='E', array=self.flux_field)
         cols = pyfits.ColDefs([col1, col2, col3])
         tbhdu = pyfits.BinTableHDU.from_columns(cols)
-        tbhdu.writeto(filename, clobber=True)
+        tbhdu.writeto(filename, overwrite=True)
 
     @parallel_root_only
     def _write_spectrum_hdf5(self, filename):

--- a/trident/ion_balance.py
+++ b/trident/ion_balance.py
@@ -257,6 +257,11 @@ def add_ion_fields(ds, ions, ftype='gas',
     if particle_type == 'auto':
         particle_type = _determine_particle_type(ds)
 
+    if particle_type:
+        sampling_type = "particle"
+    else:
+        sampling_type = "cell"
+
     if ionization_table is None:
         ionization_table = ion_table_filepath
 
@@ -385,22 +390,27 @@ def add_ion_fraction_field(atom, ion, ds, ftype="gas",
     if particle_type == 'auto':
         particle_type = _determine_particle_type(ds)
 
+    if particle_type:
+        sampling_type = "particle"
+    else:
+        sampling_type = "cell"
+
     if ionization_table is None:
         ionization_table = ion_table_filepath
 
     if (ftype, "log_nH") not in ds.derived_field_list:
         ds.add_field((ftype, "log_nH"), function=_log_nH, units="",
-                     particle_type=particle_type, 
+                     sampling_type=sampling_type,
                      force_override=force_override)
 
     if (ftype, "redshift") not in ds.derived_field_list:
         ds.add_field((ftype, "redshift"), function=_redshift, units="",
-                     particle_type=particle_type,
+                     sampling_type=sampling_type,
                      force_override=force_override)
 
     if (ftype, "log_T") not in ds.derived_field_list:
         ds.add_field((ftype, "log_T"), function=_log_T, units="",
-                     particle_type=particle_type,
+                     sampling_type=sampling_type,
                      force_override=force_override)
 
     atom = atom.capitalize()
@@ -423,7 +433,7 @@ def add_ion_fraction_field(atom, ion, ds, ftype="gas",
         del ionTable
 
     ds.add_field((ftype, field), function=_ion_fraction_field, units="",
-                 particle_type=particle_type, force_override=force_override)
+                 sampling_type=sampling_type, force_override=force_override)
     if ion == 1: # add aliased field too
         ds.field_info.alias((ftype, alias_field), (ftype, field))
         ds.derived_field_list.append((ftype, alias_field))
@@ -530,6 +540,11 @@ def add_ion_number_density_field(atom, ion, ds, ftype="gas",
     if particle_type == 'auto':
         particle_type = _determine_particle_type(ds)
 
+    if particle_type:
+        sampling_type = "particle"
+    else:
+        sampling_type = "cell"
+
     if ionization_table is None:
         ionization_table = ion_table_filepath
     atom = atom.capitalize()
@@ -549,7 +564,7 @@ def add_ion_number_density_field(atom, ion, ds, ftype="gas",
                            force_override=force_override,
                            particle_type=particle_type)
     ds.add_field((ftype, field),function=_ion_number_density,
-                 units="cm**-3", particle_type=particle_type, 
+                 units="cm**-3", sampling_type=sampling_type,
                  force_override=force_override)
     if ion == 1: # add aliased field too
         ds.field_info.alias((ftype, alias_field), (ftype, field))
@@ -657,6 +672,11 @@ def add_ion_density_field(atom, ion, ds, ftype="gas",
     if particle_type == 'auto':
         particle_type = _determine_particle_type(ds)
 
+    if particle_type:
+        sampling_type = "particle"
+    else:
+        sampling_type = "cell"
+
     if ionization_table is None:
         ionization_table = ion_table_filepath
     atom = atom.capitalize()
@@ -677,7 +697,7 @@ def add_ion_density_field(atom, ion, ds, ftype="gas",
                                  force_override=force_override,
                                  particle_type=particle_type)
     ds.add_field((ftype, field), function=_ion_density,
-                 units="g/cm**3", particle_type=particle_type,
+                 units="g/cm**3", sampling_type=sampling_type,
                  force_override=force_override)
     if ion == 1: # add aliased field too
         ds.field_info.alias((ftype, alias_field), (ftype, field))
@@ -786,6 +806,11 @@ def add_ion_mass_field(atom, ion, ds, ftype="gas",
     if particle_type == 'auto':
         particle_type = _determine_particle_type(ds)
 
+    if particle_type:
+        sampling_type = "particle"
+    else:
+        sampling_type = "cell"
+
     if ionization_table is None:
         ionization_table = ion_table_filepath
     atom = atom.capitalize()
@@ -806,7 +831,7 @@ def add_ion_mass_field(atom, ion, ds, ftype="gas",
                           force_override=force_override,
                           particle_type=particle_type)
     ds.add_field((ftype, field), function=_ion_mass, units=r"g",
-                 particle_type=particle_type,
+                 sampling_type=sampling_type,
                  force_override=force_override)
     if ion == 1: # add aliased field too
         ds.field_info.alias((ftype, alias_field), (ftype, field))
@@ -838,7 +863,8 @@ def _ion_mass(field, data):
     prefix = field_name.split("_mass")[0]
     suffix = field_name.split("_mass")[-1]
     density_field_name = "%s_density%s" % (prefix, suffix)
-    if data.ds.field_info[(ftype, density_field_name)].particle_type:
+    if data.ds.field_info[
+            (ftype, density_field_name)].sampling_type == "particle":
         fraction_field_name = "%s_ion_fraction%s" % (prefix, suffix)
         return data[ftype, fraction_field_name] * \
           data[ftype, "particle_mass"]

--- a/trident/ion_balance.py
+++ b/trident/ion_balance.py
@@ -24,6 +24,7 @@ import numpy as np
 import h5py
 import copy
 import os
+import warnings
 from trident.config import \
     ion_table_filepath
 from trident.line_database import \
@@ -137,7 +138,8 @@ def add_ion_fields(ds, ions, ftype='gas',
                    field_suffix=False, 
                    line_database=None,
                    force_override=False,
-                   particle_type='auto'):
+                   sampling_type='auto',
+                   particle_type=None):
     """
     Preferred method for adding ion fields to a yt dataset.
 
@@ -235,8 +237,16 @@ def add_ion_fields(ds, ions, ftype='gas',
         remain untouched.
         Default: False
 
+    :sampling_type: string, optional
+
+        Set to 'particle' if the field should be for particles.
+        Set to 'cell' if the field should be for grids/cells.
+        Set to 'auto' for this to be determined automatically.
+        Default: 'auto'
+
     :particle_type: boolean, optional
 
+        This is deprecated in favor of 'sampling_type'.
         Set to True if you are adding ion fields to particles, as specified
         by the 'ftype'.  Set to False if you are not.  Set to 'auto', if
         you want the code to autodetermine if the field specified by the
@@ -254,13 +264,19 @@ def add_ion_fields(ds, ions, ftype='gas',
     >>> trident.add_ion_fields(ds, ions=['H II', 'C III', 'Mg'])
     """
     ion_list = []
-    if particle_type == 'auto':
+    if particle_type is not None:
+        warnings.Warn('The "particle_type" keyword is deprecated. '
+                      'Please use "sampling_type" instead.', stacklevel=2)
+        sampling_type = None
+
+    if sampling_type == 'auto' or particle_type == 'auto':
         particle_type = _determine_particle_type(ds)
 
-    if particle_type:
-        sampling_type = "particle"
-    else:
-        sampling_type = "cell"
+    if particle_type is not None:
+        if particle_type:
+            sampling_type = "particle"
+        else:
+            sampling_type = "cell"
 
     if ionization_table is None:
         ionization_table = ion_table_filepath
@@ -301,13 +317,14 @@ def add_ion_fields(ds, ions, ftype='gas',
     for (atom, ion) in ion_list:
         add_ion_mass_field(atom, ion, ds, ftype, ionization_table,
             field_suffix=field_suffix, force_override=force_override, 
-            particle_type=particle_type)
+            sampling_type=sampling_type)
 
 def add_ion_fraction_field(atom, ion, ds, ftype="gas",
                            ionization_table=None,
                            field_suffix=False,
                            force_override=False,
-                           particle_type='auto'):
+                           sampling_type='auto',
+                           particle_type=None):
     """
     Add ion fraction field to a yt dataset for the desired ion.
 
@@ -368,8 +385,16 @@ def add_ion_fraction_field(atom, ion, ds, ftype="gas",
         remain untouched.
         Default: False
 
+    :sampling_type: string, optional
+
+        Set to 'particle' if the field should be for particles.
+        Set to 'cell' if the field should be for grids/cells.
+        Set to 'auto' for this to be determined automatically.
+        Default: 'auto'
+
     :particle_type: boolean, optional
 
+        This is deprecated in favor of 'sampling_type'.
         Set to True if you are adding ion fields to particles, as specified
         by the 'ftype'.  Set to False if you are not.  Set to 'auto', if
         you want the code to autodetermine if the field specified by the
@@ -387,13 +412,19 @@ def add_ion_fraction_field(atom, ion, ds, ftype="gas",
     >>> yt.ProjectionPlot(ds, 'x', 'C_p3_ion_fraction').save()
     """
 
-    if particle_type == 'auto':
+    if particle_type is not None:
+        warnings.Warn('The "particle_type" keyword is deprecated. '
+                      'Please use "sampling_type" instead.', stacklevel=2)
+        sampling_type = None
+
+    if sampling_type == 'auto' or particle_type == 'auto':
         particle_type = _determine_particle_type(ds)
 
-    if particle_type:
-        sampling_type = "particle"
-    else:
-        sampling_type = "cell"
+    if particle_type is not None:
+        if particle_type:
+            sampling_type = "particle"
+        else:
+            sampling_type = "cell"
 
     if ionization_table is None:
         ionization_table = ion_table_filepath
@@ -439,7 +470,7 @@ def add_ion_fraction_field(atom, ion, ds, ftype="gas",
         ds.derived_field_list.append((ftype, alias_field))
 
     # if ion particle field, add a smoothed deposited version to gas fields
-    if particle_type:
+    if sampling_type == 'particle':
         new_field = ds.add_smoothed_particle_field((ftype, field))
         if ftype != "gas":
             ds.field_info.alias(("gas", field), new_field)
@@ -452,7 +483,8 @@ def add_ion_number_density_field(atom, ion, ds, ftype="gas",
                                  ionization_table=None,
                                  field_suffix=False,
                                  force_override=False,
-                                 particle_type='auto'):
+                                 sampling_type='auto',
+                                 particle_type=None):
     """
     Add ion number density field to a yt dataset for the desired ion.
 
@@ -519,8 +551,16 @@ def add_ion_number_density_field(atom, ion, ds, ftype="gas",
         remain untouched.
         Default: False
 
+    :sampling_type: string, optional
+
+        Set to 'particle' if the field should be for particles.
+        Set to 'cell' if the field should be for grids/cells.
+        Set to 'auto' for this to be determined automatically.
+        Default: 'auto'
+
     :particle_type: boolean, optional
 
+        This is deprecated in favor of 'sampling_type'.
         Set to True if you are adding ion fields to particles, as specified
         by the 'ftype'.  Set to False if you are not.  Set to 'auto', if
         you want the code to autodetermine if the field specified by the
@@ -537,13 +577,20 @@ def add_ion_number_density_field(atom, ion, ds, ftype="gas",
     >>> trident.add_ion_number_density('C', 4, ds)
     >>> yt.ProjectionPlot(ds, 'x', 'C_p3_number_density').save()
     """
-    if particle_type == 'auto':
+
+    if particle_type is not None:
+        warnings.Warn('The "particle_type" keyword is deprecated. '
+                      'Please use "sampling_type" instead.', stacklevel=2)
+        sampling_type = None
+
+    if sampling_type == 'auto' or particle_type == 'auto':
         particle_type = _determine_particle_type(ds)
 
-    if particle_type:
-        sampling_type = "particle"
-    else:
-        sampling_type = "cell"
+    if particle_type is not None:
+        if particle_type:
+            sampling_type = "particle"
+        else:
+            sampling_type = "cell"
 
     if ionization_table is None:
         ionization_table = ion_table_filepath
@@ -562,7 +609,7 @@ def add_ion_number_density_field(atom, ion, ds, ftype="gas",
     add_ion_fraction_field(atom, ion, ds, ftype, ionization_table,
                            field_suffix=field_suffix, 
                            force_override=force_override,
-                           particle_type=particle_type)
+                           sampling_type=sampling_type)
     ds.add_field((ftype, field),function=_ion_number_density,
                  units="cm**-3", sampling_type=sampling_type,
                  force_override=force_override)
@@ -571,7 +618,7 @@ def add_ion_number_density_field(atom, ion, ds, ftype="gas",
         ds.derived_field_list.append((ftype, alias_field))
 
     # if ion particle field, add a smoothed deposited version to gas fields
-    if particle_type:
+    if sampling_type == 'particle':
         new_field = ds.add_smoothed_particle_field((ftype, field))
         if ftype != "gas":
             ds.field_info.alias(("gas", field), new_field)
@@ -584,7 +631,8 @@ def add_ion_density_field(atom, ion, ds, ftype="gas",
                           ionization_table=None,
                           field_suffix=False,
                           force_override=False,
-                          particle_type='auto'):
+                          sampling_type='auto',
+                          particle_type=None):
     """
     Add ion mass density field to a yt dataset for the desired ion.
 
@@ -651,8 +699,16 @@ def add_ion_density_field(atom, ion, ds, ftype="gas",
         remain untouched.
         Default: False
 
+    :sampling_type: string, optional
+
+        Set to 'particle' if the field should be for particles.
+        Set to 'cell' if the field should be for grids/cells.
+        Set to 'auto' for this to be determined automatically.
+        Default: 'auto'
+
     :particle_type: boolean, optional
 
+        This is deprecated in favor of 'sampling_type'.
         Set to True if you are adding ion fields to particles, as specified
         by the 'ftype'.  Set to False if you are not.  Set to 'auto', if
         you want the code to autodetermine if the field specified by the
@@ -669,13 +725,20 @@ def add_ion_density_field(atom, ion, ds, ftype="gas",
     >>> trident.add_ion_density_field('C', 4, ds)
     >>> yt.ProjectionPlot(ds, 'x', 'C_p3_density').save()
     """
-    if particle_type == 'auto':
+
+    if particle_type is not None:
+        warnings.Warn('The "particle_type" keyword is deprecated. '
+                      'Please use "sampling_type" instead.', stacklevel=2)
+        sampling_type = None
+
+    if sampling_type == 'auto' or particle_type == 'auto':
         particle_type = _determine_particle_type(ds)
 
-    if particle_type:
-        sampling_type = "particle"
-    else:
-        sampling_type = "cell"
+    if particle_type is not None:
+        if particle_type:
+            sampling_type = "particle"
+        else:
+            sampling_type = "cell"
 
     if ionization_table is None:
         ionization_table = ion_table_filepath
@@ -695,7 +758,7 @@ def add_ion_density_field(atom, ion, ds, ftype="gas",
     add_ion_number_density_field(atom, ion, ds, ftype, ionization_table,
                                  field_suffix=field_suffix,
                                  force_override=force_override,
-                                 particle_type=particle_type)
+                                 sampling_type=sampling_type)
     ds.add_field((ftype, field), function=_ion_density,
                  units="g/cm**3", sampling_type=sampling_type,
                  force_override=force_override)
@@ -704,7 +767,7 @@ def add_ion_density_field(atom, ion, ds, ftype="gas",
         ds.derived_field_list.append((ftype, alias_field))
 
     # if ion particle field, add a smoothed deposited version to gas fields
-    if particle_type:
+    if sampling_type == 'particle':
         new_field = ds.add_smoothed_particle_field((ftype, field))
         if ftype != "gas":
             ds.field_info.alias(("gas", field), new_field)
@@ -717,7 +780,8 @@ def add_ion_mass_field(atom, ion, ds, ftype="gas",
                        ionization_table=None,
                        field_suffix=False,
                        force_override=False,
-                       particle_type='auto'):
+                       sampling_type='auto',
+                       particle_type=None):
     """
     Add ion mass field to a yt dataset for the desired ion.
 
@@ -785,8 +849,16 @@ def add_ion_mass_field(atom, ion, ds, ftype="gas",
         remain untouched.
         Default: False
 
+    :sampling_type: string, optional
+
+        Set to 'particle' if the field should be for particles.
+        Set to 'cell' if the field should be for grids/cells.
+        Set to 'auto' for this to be determined automatically.
+        Default: 'auto'
+
     :particle_type: boolean, optional
 
+        This is deprecated in favor of 'sampling_type'.
         Set to True if you are adding ion fields to particles, as specified
         by the 'ftype'.  Set to False if you are not.  Set to 'auto', if
         you want the code to autodetermine if the field specified by the
@@ -803,13 +875,20 @@ def add_ion_mass_field(atom, ion, ds, ftype="gas",
     >>> trident.add_ion_mass_field('C', 4, ds)
     >>> yt.ProjectionPlot(ds, 'x', 'C_p3_mass').save()
     """
-    if particle_type == 'auto':
+
+    if particle_type is not None:
+        warnings.Warn('The "particle_type" keyword is deprecated. '
+                      'Please use "sampling_type" instead.', stacklevel=2)
+        sampling_type = None
+
+    if sampling_type == 'auto' or particle_type == 'auto':
         particle_type = _determine_particle_type(ds)
 
-    if particle_type:
-        sampling_type = "particle"
-    else:
-        sampling_type = "cell"
+    if particle_type is not None:
+        if particle_type:
+            sampling_type = "particle"
+        else:
+            sampling_type = "cell"
 
     if ionization_table is None:
         ionization_table = ion_table_filepath
@@ -829,7 +908,7 @@ def add_ion_mass_field(atom, ion, ds, ftype="gas",
     add_ion_density_field(atom, ion, ds, ftype, ionization_table,
                           field_suffix=field_suffix,
                           force_override=force_override,
-                          particle_type=particle_type)
+                          sampling_type=sampling_type)
     ds.add_field((ftype, field), function=_ion_mass, units=r"g",
                  sampling_type=sampling_type,
                  force_override=force_override)
@@ -838,7 +917,7 @@ def add_ion_mass_field(atom, ion, ds, ftype="gas",
         ds.derived_field_list.append((ftype, alias_field))
 
     # if ion particle field, add a smoothed deposited version to gas fields
-    if particle_type:
+    if sampling_type == 'particle':
         new_field = ds.add_smoothed_particle_field((ftype, field))
         if ftype != "gas":
             ds.field_info.alias(("gas", field), new_field)

--- a/trident/ion_balance.py
+++ b/trident/ion_balance.py
@@ -133,6 +133,27 @@ def _log_T(field, data):
         ftype = "gas"
     return np.log10(data[ftype, "temperature"])
 
+def _determine_sampling_type(ds, sampling_type, particle_type):
+    """
+    Helper function for figuring out the field type used for ion balance
+    fields.
+    """
+    if particle_type is not None:
+        warnings.Warn('The "particle_type" keyword is deprecated. '
+                      'Please use "sampling_type" instead.', stacklevel=2)
+        sampling_type = None
+
+    if sampling_type == 'auto' or particle_type == 'auto':
+        particle_type = _determine_particle_type(ds)
+
+    if particle_type is not None:
+        if particle_type:
+            sampling_type = "particle"
+        else:
+            sampling_type = "cell"
+
+    return sampling_type
+
 def add_ion_fields(ds, ions, ftype='gas', 
                    ionization_table=None, 
                    field_suffix=False, 
@@ -264,19 +285,8 @@ def add_ion_fields(ds, ions, ftype='gas',
     >>> trident.add_ion_fields(ds, ions=['H II', 'C III', 'Mg'])
     """
     ion_list = []
-    if particle_type is not None:
-        warnings.Warn('The "particle_type" keyword is deprecated. '
-                      'Please use "sampling_type" instead.', stacklevel=2)
-        sampling_type = None
-
-    if sampling_type == 'auto' or particle_type == 'auto':
-        particle_type = _determine_particle_type(ds)
-
-    if particle_type is not None:
-        if particle_type:
-            sampling_type = "particle"
-        else:
-            sampling_type = "cell"
+    sampling_type = \
+      _determine_sampling_type(ds, sampling_type, particle_type)
 
     if ionization_table is None:
         ionization_table = ion_table_filepath
@@ -412,19 +422,8 @@ def add_ion_fraction_field(atom, ion, ds, ftype="gas",
     >>> yt.ProjectionPlot(ds, 'x', 'C_p3_ion_fraction').save()
     """
 
-    if particle_type is not None:
-        warnings.Warn('The "particle_type" keyword is deprecated. '
-                      'Please use "sampling_type" instead.', stacklevel=2)
-        sampling_type = None
-
-    if sampling_type == 'auto' or particle_type == 'auto':
-        particle_type = _determine_particle_type(ds)
-
-    if particle_type is not None:
-        if particle_type:
-            sampling_type = "particle"
-        else:
-            sampling_type = "cell"
+    sampling_type = \
+      _determine_sampling_type(ds, sampling_type, particle_type)
 
     if ionization_table is None:
         ionization_table = ion_table_filepath
@@ -578,19 +577,8 @@ def add_ion_number_density_field(atom, ion, ds, ftype="gas",
     >>> yt.ProjectionPlot(ds, 'x', 'C_p3_number_density').save()
     """
 
-    if particle_type is not None:
-        warnings.Warn('The "particle_type" keyword is deprecated. '
-                      'Please use "sampling_type" instead.', stacklevel=2)
-        sampling_type = None
-
-    if sampling_type == 'auto' or particle_type == 'auto':
-        particle_type = _determine_particle_type(ds)
-
-    if particle_type is not None:
-        if particle_type:
-            sampling_type = "particle"
-        else:
-            sampling_type = "cell"
+    sampling_type = \
+      _determine_sampling_type(ds, sampling_type, particle_type)
 
     if ionization_table is None:
         ionization_table = ion_table_filepath
@@ -726,19 +714,8 @@ def add_ion_density_field(atom, ion, ds, ftype="gas",
     >>> yt.ProjectionPlot(ds, 'x', 'C_p3_density').save()
     """
 
-    if particle_type is not None:
-        warnings.Warn('The "particle_type" keyword is deprecated. '
-                      'Please use "sampling_type" instead.', stacklevel=2)
-        sampling_type = None
-
-    if sampling_type == 'auto' or particle_type == 'auto':
-        particle_type = _determine_particle_type(ds)
-
-    if particle_type is not None:
-        if particle_type:
-            sampling_type = "particle"
-        else:
-            sampling_type = "cell"
+    sampling_type = \
+      _determine_sampling_type(ds, sampling_type, particle_type)
 
     if ionization_table is None:
         ionization_table = ion_table_filepath
@@ -876,19 +853,8 @@ def add_ion_mass_field(atom, ion, ds, ftype="gas",
     >>> yt.ProjectionPlot(ds, 'x', 'C_p3_mass').save()
     """
 
-    if particle_type is not None:
-        warnings.Warn('The "particle_type" keyword is deprecated. '
-                      'Please use "sampling_type" instead.', stacklevel=2)
-        sampling_type = None
-
-    if sampling_type == 'auto' or particle_type == 'auto':
-        particle_type = _determine_particle_type(ds)
-
-    if particle_type is not None:
-        if particle_type:
-            sampling_type = "particle"
-        else:
-            sampling_type = "cell"
+    sampling_type = \
+      _determine_sampling_type(ds, sampling_type, particle_type)
 
     if ionization_table is None:
         ionization_table = ion_table_filepath


### PR DESCRIPTION
This threads the `sampling_type` keyword through all of the yt `add_field` calls following the new practice.  We add this keyword for our functions as well and deprecate `particle_type`.

Update: fixed astropy deprecation warning as well.