### PR TITLE
Closes #9 Re-enabling gizmo tests with slimmed down sample data.

### DIFF
--- a/tests/test_absorption_spectrum.py
+++ b/tests/test_absorption_spectrum.py
@@ -15,7 +15,6 @@ import numpy as np
 from numpy.testing import \
     assert_array_equal
 import os
-import unittest
 from yt.convenience import load
 from yt.funcs import ensure_dir
 from yt.testing import \
@@ -239,7 +238,6 @@ class AbsorptionSpectrumTest(TempDirTest):
                                             line_list_file='lines.txt',
                                             use_peculiar_velocity=True)
 
-    @unittest.skip("temporarily disabled")
     @h5_answer_test(assert_array_rel_equal, decimals=12)
     def test_absorption_spectrum_cosmo_sph(self):
         """
@@ -281,7 +279,6 @@ class AbsorptionSpectrumTest(TempDirTest):
                                             use_peculiar_velocity=True)
         return filename
 
-    @unittest.skip("temporarily disabled")
     @h5_answer_test(assert_array_rel_equal, decimals=16)
     def test_absorption_spectrum_non_cosmo_sph(self):
         """

--- a/tests/test_datasets.txt
+++ b/tests/test_datasets.txt
@@ -1,4 +1,5 @@
 http://trident-project.org/data/tests/enzo_small.tar.gz
+http://trident-project.org/data/tests/gizmo_cosmology_plus.tar.gz
 http://yt-project.org/data/enzo_cosmology_plus.tar.gz
 http://yt-project.org/data/IsolatedGalaxy.tar.gz
 http://yt-project.org/data/FIRE_M12i_ref11.tar.gz


### PR DESCRIPTION
The sample data only contains the three datasets necessary for the tests, plus supplementary files.