### PR TITLE
Changes all internal instances of particle_type to sampling_type

### DIFF
--- a/trident/ion_balance.py
+++ b/trident/ion_balance.py
@@ -31,7 +31,7 @@ from trident.line_database import \
     LineDatabase, \
     uniquify
 from trident.utilities import \
-    _determine_particle_type
+    _determine_dataset_sampling_type
 from trident.roman import \
     from_roman
 
@@ -144,7 +144,7 @@ def _determine_sampling_type(ds, sampling_type, particle_type):
         sampling_type = None
 
     if sampling_type == 'auto' or particle_type == 'auto':
-        particle_type = _determine_particle_type(ds)
+        sampling_type = _determine_dataset_sampling_type(ds)
 
     if particle_type is not None:
         if particle_type:

--- a/trident/ion_balance.py
+++ b/trident/ion_balance.py
@@ -139,7 +139,7 @@ def _determine_sampling_type(ds, sampling_type, particle_type):
     fields.
     """
     if particle_type is not None:
-        warnings.Warn('The "particle_type" keyword is deprecated. '
+        warnings.warn('The "particle_type" keyword is deprecated. '
                       'Please use "sampling_type" instead.', stacklevel=2)
         sampling_type = None
 


### PR DESCRIPTION
Previously, if you used basic functionality in trident with particle datasets, it would default to using the `particle_type` flag, which is now deprecated.  So you'd get a warning and there was a bunch of extra logic to navigate internally.  This simplifies that by internally using `sampling_type`, although we still allow the user to use the deprecated `particle_type` kwarg when adding fields.

