### PR TITLE
Updating .travis.yml to include current gold standard

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ env:
     TRIDENT_ION_DATA=$HOME/.trident
     TRIDENT_ANSWER_DATA=$HOME/answer_test_data
     YT_GOLD=38b79c094ca9
-    TRIDENT_GOLD=gold-standard-v1
+    TRIDENT_GOLD=test-standard-v2
 
 matrix:
   include:

--- a/doc/source/testing.rst
+++ b/doc/source/testing.rst
@@ -110,7 +110,7 @@ with these versions of the code.  Lastly, set the
    
    Latest Gold Standard Commit Tags
    yt = 38b79c094ca9
-   Trident = gold-standard-v1
+   Trident = test-standard-v1
 
    To update to them, `git checkout <tag>` in appropriate repository
 
@@ -118,7 +118,7 @@ with these versions of the code.  Lastly, set the
    $ git checkout 38b79c094ca9
    $ pip install -e .
    $ cd /path/to/trident
-   $ git checkout gold-standard-v1
+   $ git checkout test-standard-v1
    $ pip install -e .
    $ export TRIDENT_GENERATE_TEST_RESULTS=1
    $ cd tests
@@ -143,15 +143,15 @@ the next gold standard iteration.  You can see the current iteration by looking
 in the ``.travis.yml`` file at the ``TRIDENT_GOLD`` entry--enumerate this and
 tag the changeset.  Update the ``.travis.yml`` file so that the ``YT_GOLD`` and
 ``TRIDENT_GOLD`` entries point to your desired changeset and tag.  Finally,
-you have to explicitly push the new tag (hereafter ``gold-standard-v2``) to 
+you have to explicitly push the new tag (hereafter ``test-standard-v2``) to 
 the repository.
 
 .. code-block:: bash
 
-   $ git tag gold-standard-v2 <trident-changeset>
+   $ git tag test-standard-v2 <trident-changeset>
    $ ... edit .travis.yml files to update YT_GOLD=<yt changeset>
-   $ ... and TRIDENT_GOLD=<gold-standard-v2
+   $ ... and TRIDENT_GOLD=<test-standard-v2
    $ git add .travis.yml
    $ git commit
    $ git push origin
-   $ git push origin gold-standard-v2
+   $ git push origin test-standard-v2

--- a/tests/test_ion_balance.py
+++ b/tests/test_ion_balance.py
@@ -29,6 +29,7 @@ import tempfile
 import shutil
 from trident.testing import \
     answer_test_data_dir
+import os
 
 import numpy as np
 

--- a/tests/test_ion_balance.py
+++ b/tests/test_ion_balance.py
@@ -12,21 +12,30 @@ Tests for ion balance code
 #-----------------------------------------------------------------------------
 
 from __future__ import absolute_import
-import trident as tri
 from trident.ion_balance import \
     add_ion_fraction_field, \
     add_ion_number_density_field, \
     add_ion_density_field, \
-    add_ion_mass_field
-import yt
+    add_ion_mass_field, \
+    add_ion_fields
+from yt import \
+    load, \
+    SlicePlot
 from yt.testing import \
     fake_random_ds, \
     fake_amr_ds, \
     fake_particle_ds
 import tempfile
 import shutil
+from trident.testing import \
+    answer_test_data_dir
 
 import numpy as np
+
+ISO_GALAXY = os.path.join(answer_test_data_dir, 
+                'IsolatedGalaxy/galaxy0030/galaxy0030')
+FIRE_SIM = os.path.join(answer_test_data_dir,
+                'FIRE_M12i_ref11/snapshot_600.hdf5')
 
 def test_add_ion_fraction_field_to_grid_ds():
     """
@@ -44,7 +53,7 @@ def test_add_ion_fraction_field_to_grid_ds():
     assert isinstance(ad[field], np.ndarray)
 
     dirpath = tempfile.mkdtemp()
-    yt.SlicePlot(ds, 'x', field).save(dirpath)
+    SlicePlot(ds, 'x', field).save(dirpath)
     shutil.rmtree(dirpath)
 
 def test_add_ion_number_density_field_to_grid_ds():
@@ -63,7 +72,7 @@ def test_add_ion_number_density_field_to_grid_ds():
     assert isinstance(ad[field], np.ndarray)
 
     dirpath = tempfile.mkdtemp()
-    yt.SlicePlot(ds, 'x', field).save(dirpath)
+    SlicePlot(ds, 'x', field).save(dirpath)
     shutil.rmtree(dirpath)
 
 def test_add_ion_density_field_to_grid_ds():
@@ -82,7 +91,7 @@ def test_add_ion_density_field_to_grid_ds():
     assert isinstance(ad[field], np.ndarray)
 
     dirpath = tempfile.mkdtemp()
-    yt.SlicePlot(ds, 'x', field).save(dirpath)
+    SlicePlot(ds, 'x', field).save(dirpath)
     shutil.rmtree(dirpath)
 
 def test_add_ion_mass_field_to_grid_ds():
@@ -101,7 +110,7 @@ def test_add_ion_mass_field_to_grid_ds():
     assert isinstance(ad[field], np.ndarray)
 
     dirpath = tempfile.mkdtemp()
-    yt.SlicePlot(ds, 'x', field).save(dirpath)
+    SlicePlot(ds, 'x', field).save(dirpath)
     shutil.rmtree(dirpath)
 
 def test_add_ion_fraction_fields_to_amr_ds():
@@ -118,7 +127,7 @@ def test_add_ion_fraction_fields_to_amr_ds():
     assert isinstance(ad[field], np.ndarray)
 
     dirpath = tempfile.mkdtemp()
-    yt.SlicePlot(ds, 'x', field).save(dirpath)
+    SlicePlot(ds, 'x', field).save(dirpath)
     shutil.rmtree(dirpath)
 
 def test_add_ion_number_density_fields_to_amr_ds():
@@ -135,7 +144,7 @@ def test_add_ion_number_density_fields_to_amr_ds():
     assert isinstance(ad[field], np.ndarray)
 
     dirpath = tempfile.mkdtemp()
-    yt.SlicePlot(ds, 'x', field).save(dirpath)
+    SlicePlot(ds, 'x', field).save(dirpath)
     shutil.rmtree(dirpath)
 
 def test_add_ion_density_fields_to_amr_ds():
@@ -152,7 +161,7 @@ def test_add_ion_density_fields_to_amr_ds():
     assert isinstance(ad[field], np.ndarray)
 
     dirpath = tempfile.mkdtemp()
-    yt.SlicePlot(ds, 'x', field).save(dirpath)
+    SlicePlot(ds, 'x', field).save(dirpath)
     shutil.rmtree(dirpath)
 
 def test_add_ion_mass_fields_to_amr_ds():
@@ -169,7 +178,7 @@ def test_add_ion_mass_fields_to_amr_ds():
     assert isinstance(ad[field], np.ndarray)
 
     dirpath = tempfile.mkdtemp()
-    yt.SlicePlot(ds, 'x', field).save(dirpath)
+    SlicePlot(ds, 'x', field).save(dirpath)
     shutil.rmtree(dirpath)
 
 def test_add_ion_fields_to_grid_ds():
@@ -183,7 +192,7 @@ def test_add_ion_fields_to_grid_ds():
     ftype = 'stream'
     ad = ds.all_data()
     ions = ['H', 'O', 'N V']
-    tri.add_ion_fields(ds, ions, ftype='stream')
+    add_ion_fields(ds, ions, ftype='stream')
     fields = ['H_ion_fraction', 'H_p0_number_density', 'O_p5_mass', 'N_p4_density']
     # Assure that a sampling of fields are added and can be sliced
     dirpath = tempfile.mkdtemp()
@@ -191,7 +200,7 @@ def test_add_ion_fields_to_grid_ds():
         field = (ftype, field)
         assert field in ds.derived_field_list
         assert isinstance(ad[field], np.ndarray)
-        yt.SlicePlot(ds, 'x', field).save(dirpath)
+        SlicePlot(ds, 'x', field).save(dirpath)
     shutil.rmtree(dirpath)
 
 def test_add_all_ion_fields_to_grid_ds():
@@ -204,7 +213,7 @@ def test_add_all_ion_fields_to_grid_ds():
                                    'cm/s', 'K', ''))
     ftype = 'stream'
     ad = ds.all_data()
-    tri.add_ion_fields(ds, 'all', ftype='stream')
+    add_ion_fields(ds, 'all', ftype='stream')
     fields = ['H_ion_fraction', 'H_p0_number_density', 'O_p5_mass', 'N_p4_density']
     # Assure that a sampling of fields are added and can be sliced
     dirpath = tempfile.mkdtemp()
@@ -212,7 +221,7 @@ def test_add_all_ion_fields_to_grid_ds():
         field = (ftype, field)
         assert field in ds.derived_field_list
         assert isinstance(ad[field], np.ndarray)
-        yt.SlicePlot(ds, 'x', field).save(dirpath)
+        SlicePlot(ds, 'x', field).save(dirpath)
     shutil.rmtree(dirpath)
 
 def test_add_all_ion_fields_to_grid_ds_from_file():
@@ -225,7 +234,7 @@ def test_add_all_ion_fields_to_grid_ds_from_file():
                                    'cm/s', 'K', ''))
     ftype = 'stream'
     ad = ds.all_data()
-    tri.add_ion_fields(ds, 'all', ftype='stream', line_database='lines.txt')
+    add_ion_fields(ds, 'all', ftype='stream', line_database='lines.txt')
     fields = ['H_ion_fraction', 'H_p0_number_density', 'O_p5_mass', 'N_p4_density']
     # Assure that a sampling of fields are added and can be sliced
     dirpath = tempfile.mkdtemp()
@@ -233,7 +242,7 @@ def test_add_all_ion_fields_to_grid_ds_from_file():
         field = (ftype, field)
         assert field in ds.derived_field_list
         assert isinstance(ad[field], np.ndarray)
-        yt.SlicePlot(ds, 'x', field).save(dirpath)
+        SlicePlot(ds, 'x', field).save(dirpath)
     shutil.rmtree(dirpath)
 
 def test_add_all_ion_fields_to_amr_ds():
@@ -245,7 +254,7 @@ def test_add_all_ion_fields_to_amr_ds():
     ftype = 'stream'
     ad = ds.all_data()
     ions = ['H', 'O', 'N V']
-    tri.add_ion_fields(ds, ions, ftype='stream')
+    add_ion_fields(ds, ions, ftype='stream')
     fields = ['H_ion_fraction', 'H_p0_number_density', 'O_p5_mass', 'N_p4_density']
     # Assure that a sampling of fields are added and can be sliced
     dirpath = tempfile.mkdtemp()
@@ -253,15 +262,15 @@ def test_add_all_ion_fields_to_amr_ds():
         field = (ftype, field)
         assert field in ds.derived_field_list
         assert isinstance(ad[field], np.ndarray)
-        yt.SlicePlot(ds, 'x', field).save(dirpath)
+        SlicePlot(ds, 'x', field).save(dirpath)
     shutil.rmtree(dirpath)
 
 def test_add_ion_fields_to_enzo():
     """
     Test to add various ion fields to Enzo dataset and slice on them
     """
-    ds = yt.load('IsolatedGalaxy/galaxy0030/galaxy0030')
-    tri.add_ion_fields(ds, ['H', 'O VI'], ftype='gas')
+    ds = load(ISO_GALAXY)
+    add_ion_fields(ds, ['H', 'O VI'], ftype='gas')
     ad = ds.all_data()
     fields = ['H_p0_number_density', 'O_p5_density']
     # Assure that a sampling of fields are added and can be sliced
@@ -270,15 +279,15 @@ def test_add_ion_fields_to_enzo():
         field = ('gas', field)
         assert field in ds.derived_field_list
         assert isinstance(ad[field], np.ndarray)
-        yt.SlicePlot(ds, 'x', field).save(dirpath)
+        SlicePlot(ds, 'x', field).save(dirpath)
     shutil.rmtree(dirpath)
 
 def test_add_ion_fields_to_gizmo():
     """
     Test to add various ion fields to gizmo dataset and slice on them
     """
-    ds = yt.load('FIRE_M12i_ref11/snapshot_600.hdf5')
-    tri.add_ion_fields(ds, ['H', 'O VI'], ftype='PartType0')
+    ds = load(FIRE_SIM)
+    add_ion_fields(ds, ['H', 'O VI'], ftype='PartType0')
     ad = ds.all_data()
     fields = ['H_ion_fraction', 'O_p5_mass']
     # Assure that a sampling of fields are added and can be sliced
@@ -287,5 +296,5 @@ def test_add_ion_fields_to_gizmo():
         field = ('gas', field)
         assert field in ds.derived_field_list
         assert isinstance(ad[field], np.ndarray)
-        yt.SlicePlot(ds, 'x', field).save(dirpath)
+        SlicePlot(ds, 'x', field).save(dirpath)
     shutil.rmtree(dirpath)

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -31,7 +31,7 @@ from trident.testing import \
 
 # Datasets required for running some answer tests
 enzo_small = os.path.join(answer_test_data_dir, 'enzo_small')
-FIRE = os.path.join(answer_test_data_dir, 'FIRE_M12I_ref11/snapshot_600.hdf5')
+FIRE = os.path.join(answer_test_data_dir, 'FIRE_M12i_ref11/snapshot_600.hdf5')
 err_precision = 8
 
 def test_verify():


### PR DESCRIPTION
Forgot to include the update in the .travis.yml file when I updated the answer tests in PR #17 .  Also, I changed the testing standard tags to be "test-standard-vN" instead of "gold-standard_vN", because alongside the other code version tags, it looks confusing.  Someone downloading the code might inadvertently want the latest version of the code and think that "gold-standard-v8" is more advanced than the code version of e.g., "v2.0".  

I've pushed all the appropriate tags to my repo and the main repo.  So if you've already set the gold-standard tags locally, you should delete them (e.g., git tag -d gold-standard-v1) and download the ones from the source (e.g., git fetch upstream --tags).