### PR TITLE
split and join filenames using os.sep instead of assuming unix

### DIFF
--- a/trident/config.py
+++ b/trident/config.py
@@ -52,9 +52,9 @@ def trident_path():
 
     >>> print(trident_path())
     """
-    path_list = os.path.dirname(__file__).split('/')[:-1]
+    path_list = os.path.dirname(__file__).split(os.sep)[:-1]
     path_list.append('trident')
-    return '/'.join(path_list)
+    return os.sep.join(path_list)
 
 def create_config():
     """

--- a/trident/ion_balance.py
+++ b/trident/ion_balance.py
@@ -452,9 +452,9 @@ def add_ion_fraction_field(atom, ion, ds, ftype="gas",
     else:
         field = "%s_p%d_ion_fraction" % (atom, ion-1)
     if field_suffix:
-        field += "_%s" % ionization_table.split("/")[-1].split(".h5")[0]
+        field += "_%s" % ionization_table.split(os.sep)[-1].split(".h5")[0]
         if ion == 1:
-            alias_field += "_%s" % ionization_table.split("/")[-1].split(".h5")[0]
+            alias_field += "_%s" % ionization_table.split(os.sep)[-1].split(".h5")[0]
 
     if not field in table_store:
         ionTable = IonBalanceTable(ionization_table, atom)
@@ -590,9 +590,9 @@ def add_ion_number_density_field(atom, ion, ds, ftype="gas",
     else:
         field = "%s_p%d_number_density" % (atom, ion-1)
     if field_suffix:
-        field += "_%s" % ionization_table.split("/")[-1].split(".h5")[0]
+        field += "_%s" % ionization_table.split(os.sep)[-1].split(".h5")[0]
         if ion == 1:
-            alias_field += "_%s" % ionization_table.split("/")[-1].split(".h5")[0]
+            alias_field += "_%s" % ionization_table.split(os.sep)[-1].split(".h5")[0]
 
     add_ion_fraction_field(atom, ion, ds, ftype, ionization_table,
                            field_suffix=field_suffix, 
@@ -728,9 +728,9 @@ def add_ion_density_field(atom, ion, ds, ftype="gas",
     else:
         field = "%s_p%d_density" % (atom, ion-1)
     if field_suffix:
-        field += "_%s" % ionization_table.split("/")[-1].split(".h5")[0]
+        field += "_%s" % ionization_table.split(os.sep)[-1].split(".h5")[0]
         if ion == 1:
-            alias_field += "_%s" % ionization_table.split("/")[-1].split(".h5")[0]
+            alias_field += "_%s" % ionization_table.split(os.sep)[-1].split(".h5")[0]
 
     add_ion_number_density_field(atom, ion, ds, ftype, ionization_table,
                                  field_suffix=field_suffix,
@@ -867,9 +867,9 @@ def add_ion_mass_field(atom, ion, ds, ftype="gas",
     else:
         field = "%s_p%s_mass" % (atom, ion-1)
     if field_suffix:
-        field += "_%s" % ionization_table.split("/")[-1].split(".h5")[0]
+        field += "_%s" % ionization_table.split(os.sep)[-1].split(".h5")[0]
         if ion == 1:
-            alias_field += "_%s" % ionization_table.split("/")[-1].split(".h5")[0]
+            alias_field += "_%s" % ionization_table.split(os.sep)[-1].split(".h5")[0]
 
     add_ion_density_field(atom, ion, ds, ftype, ionization_table,
                           field_suffix=field_suffix,

--- a/trident/line_database.py
+++ b/trident/line_database.py
@@ -227,11 +227,11 @@ class LineDatabase:
         # if not, look in cwd
         filename = os.path.join(trident_path(), "data", "line_lists", filename)
         if not os.path.isfile(filename):
-            filename = filename.split('/')[-1]
+            filename = filename.split(os.sep)[-1]
         if not os.path.isfile(filename):
             raise RuntimeError("line_list %s is not found in local "
                                "directory or in trident/data/line_lists "
-                               % (filename.split('/')[-1]))
+                               % (filename.split(os.sep)[-1]))
 
         # Step through each line of text in file and add to database
         for line in open(filename).readlines():

--- a/trident/spectrum_generator.py
+++ b/trident/spectrum_generator.py
@@ -207,7 +207,7 @@ class SpectrumGenerator(AbsorptionSpectrum):
             else:
                 raise RuntimeError("ionization_table %s is not found in local "
                                    "directory or in %s" %
-                                   (filename.split('/')[-1],
+                                   (ion_table_file.split(os.sep)[-1],
                                     ion_table_dir))
         else:
             self.ionization_table = None

--- a/trident/utilities.py
+++ b/trident/utilities.py
@@ -95,7 +95,7 @@ def download_file(url, progress_bar=True, local_directory=None,
 
     # Set defaults
     if local_filename is None:
-        local_filename = url.split('/')[-1]
+        local_filename = url.split(os.sep)[-1]
     if local_directory is None:
         local_directory = '.'
     ensure_directory(local_directory)
@@ -464,8 +464,8 @@ def import_check():
     """
     """
     # Avoid astropy error when importing from trident package directory.
-    plist = os.path.dirname(os.path.abspath(__file__)).split('/')
-    package_path = '/'.join(plist[:-1])
+    plist = os.path.dirname(os.path.abspath(__file__)).split(os.sep)
+    package_path = os.sep.join(plist[:-1])
     if os.getcwd() == package_path:
         raise RuntimeError(
             """


### PR DESCRIPTION
All of these will fail on windows where the path separator is `"\"` instead of `"/"`. Using the `os` module lets you easily handle paths in a cross-platform manner.