### PR TITLE
Fully remove sampling_type and ftype for sph-viz

### DIFF
--- a/examples/gizmo_script.py
+++ b/examples/gizmo_script.py
@@ -10,7 +10,7 @@ import trident
 
 # Set the dataset filename, load it into yt and define the trajectory
 # of the LightRay.  This uses the maximum density location as the one end of
-# the ray.  Define desired spectral features to include # all H, C, N, O, and 
+# the ray.  Define desired spectral features to include all H, C, N, O, and 
 # Mg lines.
 fn = 'FIRE_M12i_ref11/snapshot_600.hdf5'
 ds = yt.load(fn)
@@ -22,10 +22,9 @@ line_list = ['H', 'C', 'N', 'O', 'Mg']
 # Make a LightRay object including all necessary fields so you can add
 # all H, C, N, O, and Mg fields to the resulting spectrum from your dataset.
 # Save LightRay to ray.h5 and use it locally as ray object.
-# Note: We use PartType0, the gas particle field type as our ftype!
 ray = trident.make_simple_ray(ds, start_position=ray_start,
                               end_position=ray_end, data_filename='ray.h5',
-                              lines=line_list, ftype='PartType0')
+                              lines=line_list)
 
 # Create a projection of the dataset in density along the x axis,
 # overplot the trajectory of the ray, and save it.

--- a/examples/working_script.py
+++ b/examples/working_script.py
@@ -18,7 +18,7 @@ line_list = ['H', 'C', 'N', 'O', 'Mg']
 # Save LightRay to ray.h5 and use it locally as ray object.
 ray = trident.make_simple_ray(ds, start_position=ray_start,
                               end_position=ray_end, data_filename='ray.h5',
-                              lines=line_list, ftype='gas')
+                              lines=line_list)
 
 # Create a projection of the dataset in density along the x axis,
 # overplot the trajectory of the ray, and save it.

--- a/tests/test_ion_balance.py
+++ b/tests/test_ion_balance.py
@@ -46,10 +46,9 @@ def test_add_ion_fraction_field_to_grid_ds():
                                    "velocity_z", "temperature", "metallicity"),
                            units= ('g/cm**3', 'cm/s', 'cm/s',
                                    'cm/s', 'K', ''))
-    ftype = 'stream'
     ad = ds.all_data()
-    add_ion_fraction_field('O', 6, ds, ftype='stream')
-    field = ('stream', 'O_p5_ion_fraction')
+    add_ion_fraction_field('O', 6, ds)
+    field = ('gas', 'O_p5_ion_fraction')
     assert field in ds.derived_field_list
     assert isinstance(ad[field], np.ndarray)
 
@@ -65,10 +64,9 @@ def test_add_ion_number_density_field_to_grid_ds():
                                    "velocity_z", "temperature", "metallicity"),
                            units= ('g/cm**3', 'cm/s', 'cm/s',
                                    'cm/s', 'K', ''))
-    ftype = 'stream'
     ad = ds.all_data()
-    add_ion_mass_field('O', 6, ds, ftype='stream')
-    field = ('stream', 'O_p5_number_density')
+    add_ion_mass_field('O', 6, ds)
+    field = ('gas', 'O_p5_number_density')
     assert field in ds.derived_field_list
     assert isinstance(ad[field], np.ndarray)
 
@@ -84,10 +82,9 @@ def test_add_ion_density_field_to_grid_ds():
                                    "velocity_z", "temperature", "metallicity"),
                            units= ('g/cm**3', 'cm/s', 'cm/s',
                                    'cm/s', 'K', ''))
-    ftype = 'stream'
     ad = ds.all_data()
-    add_ion_mass_field('O', 6, ds, ftype='stream')
-    field = ('stream', 'O_p5_density')
+    add_ion_mass_field('O', 6, ds)
+    field = ('gas', 'O_p5_density')
     assert field in ds.derived_field_list
     assert isinstance(ad[field], np.ndarray)
 
@@ -103,10 +100,9 @@ def test_add_ion_mass_field_to_grid_ds():
                                    "velocity_z", "temperature", "metallicity"),
                            units= ('g/cm**3', 'cm/s', 'cm/s',
                                    'cm/s', 'K', ''))
-    ftype = 'stream'
     ad = ds.all_data()
-    add_ion_mass_field('O', 6, ds, ftype='stream')
-    field = ('stream', 'O_p5_mass')
+    add_ion_mass_field('O', 6, ds, ftype='gas')
+    field = ('gas', 'O_p5_mass')
     assert field in ds.derived_field_list
     assert isinstance(ad[field], np.ndarray)
 
@@ -120,10 +116,9 @@ def test_add_ion_fraction_fields_to_amr_ds():
     """
     ds = fake_amr_ds(fields=("density", "velocity_x", "velocity_y",
                              "velocity_z", "temperature", "metallicity"))
-    ftype = 'stream'
     ad = ds.all_data()
-    add_ion_fraction_field('O', 6, ds, ftype='stream')
-    field = ('stream', 'O_p5_ion_fraction')
+    add_ion_fraction_field('O', 6, ds)
+    field = ('gas', 'O_p5_ion_fraction')
     assert field in ds.derived_field_list
     assert isinstance(ad[field], np.ndarray)
 
@@ -137,10 +132,9 @@ def test_add_ion_number_density_fields_to_amr_ds():
     """
     ds = fake_amr_ds(fields=("density", "velocity_x", "velocity_y",
                              "velocity_z", "temperature", "metallicity"))
-    ftype = 'stream'
     ad = ds.all_data()
-    add_ion_number_density_field('O', 6, ds, ftype='stream')
-    field = ('stream', 'O_p5_number_density')
+    add_ion_number_density_field('O', 6, ds)
+    field = ('gas', 'O_p5_number_density')
     assert field in ds.derived_field_list
     assert isinstance(ad[field], np.ndarray)
 
@@ -154,10 +148,9 @@ def test_add_ion_density_fields_to_amr_ds():
     """
     ds = fake_amr_ds(fields=("density", "velocity_x", "velocity_y",
                              "velocity_z", "temperature", "metallicity"))
-    ftype = 'stream'
     ad = ds.all_data()
-    add_ion_density_field('O', 6, ds, ftype='stream')
-    field = ('stream', 'O_p5_density')
+    add_ion_density_field('O', 6, ds)
+    field = ('gas', 'O_p5_density')
     assert field in ds.derived_field_list
     assert isinstance(ad[field], np.ndarray)
 
@@ -171,10 +164,9 @@ def test_add_ion_mass_fields_to_amr_ds():
     """
     ds = fake_amr_ds(fields=("density", "velocity_x", "velocity_y",
                              "velocity_z", "temperature", "metallicity"))
-    ftype = 'stream'
     ad = ds.all_data()
-    add_ion_mass_field('O', 6, ds, ftype='stream')
-    field = ('stream', 'O_p5_mass')
+    add_ion_mass_field('O', 6, ds)
+    field = ('gas', 'O_p5_mass')
     assert field in ds.derived_field_list
     assert isinstance(ad[field], np.ndarray)
 
@@ -190,10 +182,10 @@ def test_add_ion_fields_to_grid_ds():
                                    "velocity_z", "temperature", "metallicity"),
                            units= ('g/cm**3', 'cm/s', 'cm/s',
                                    'cm/s', 'K', ''))
-    ftype = 'stream'
+    ftype = 'gas'
     ad = ds.all_data()
     ions = ['H', 'O', 'N V']
-    add_ion_fields(ds, ions, ftype='stream')
+    add_ion_fields(ds, ions)
     fields = ['H_ion_fraction', 'H_p0_number_density', 'O_p5_mass', 'N_p4_density']
     # Assure that a sampling of fields are added and can be sliced
     dirpath = tempfile.mkdtemp()
@@ -212,9 +204,9 @@ def test_add_all_ion_fields_to_grid_ds():
                                    "velocity_z", "temperature", "metallicity"),
                            units= ('g/cm**3', 'cm/s', 'cm/s',
                                    'cm/s', 'K', ''))
-    ftype = 'stream'
+    ftype = 'gas'
     ad = ds.all_data()
-    add_ion_fields(ds, 'all', ftype='stream')
+    add_ion_fields(ds, 'all')
     fields = ['H_ion_fraction', 'H_p0_number_density', 'O_p5_mass', 'N_p4_density']
     # Assure that a sampling of fields are added and can be sliced
     dirpath = tempfile.mkdtemp()
@@ -233,7 +225,7 @@ def test_add_all_ion_fields_to_grid_ds_from_file():
                                    "velocity_z", "temperature", "metallicity"),
                            units= ('g/cm**3', 'cm/s', 'cm/s',
                                    'cm/s', 'K', ''))
-    ftype = 'stream'
+    ftype = 'gas'
     ad = ds.all_data()
     add_ion_fields(ds, 'all', ftype='stream', line_database='lines.txt')
     fields = ['H_ion_fraction', 'H_p0_number_density', 'O_p5_mass', 'N_p4_density']
@@ -252,7 +244,7 @@ def test_add_all_ion_fields_to_amr_ds():
     """
     ds = fake_amr_ds(fields=("density", "velocity_x", "velocity_y",
                              "velocity_z", "temperature", "metallicity"))
-    ftype = 'stream'
+    ftype = 'gas'
     ad = ds.all_data()
     ions = ['H', 'O', 'N V']
     add_ion_fields(ds, ions, ftype='stream')

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -213,7 +213,7 @@ class PipelineTest(TempDirTest):
         # Note: We use PartType0, the gas particle field type as our ftype!
         ray = make_simple_ray(ds, start_position=ray_start,
                               end_position=ray_end, data_filename='ray.h5',
-                              lines=line_list, ftype='PartType0')
+                              lines=line_list)
 
         # Now use the ray object to actually generate an absorption spectrum
         # Use the settings (spectral range, LSF, and spectral resolution) for COS

--- a/tests/test_ray_generator.py
+++ b/tests/test_ray_generator.py
@@ -31,7 +31,6 @@ def test_create_simple_grid_ray_with_lines():
     dirpath = tempfile.mkdtemp()
     filename = os.path.join(dirpath, 'ray.h5')
     ds = tri.make_onezone_dataset()
-    ftype = 'stream'
     ray_start = ds.arr([0., 0., 0.], 'unitary')
     ray_end = ds.arr([1., 1., 1.], 'unitary')
     ray = tri.make_simple_ray(ds, start_position=ray_start, end_position=ray_end,

--- a/trident/absorption_spectrum/absorption_spectrum.py
+++ b/trident/absorption_spectrum/absorption_spectrum.py
@@ -401,6 +401,11 @@ class AbsorptionSpectrum(object):
         # low column density absorbers can add up to a significant
         # continuum effect, we normalize min_tau by the n_absorbers.
         n_absorbers = field_data['dl'].size
+
+        if n_absorbers == 0:
+            mylog.info("No absorbers in path of LightRay.")
+            return
+
         min_tau /= n_absorbers
 
         for continuum in self.continuum_list:

--- a/trident/ion_balance.py
+++ b/trident/ion_balance.py
@@ -173,14 +173,6 @@ def add_ion_fields(ds, ions, ftype='gas',
     photoionization in the optically thin limit from a redshift-dependent
     metagalactic ionizing background using the ionization_table specified.
 
-    **WARNING**: The "ftype" must match the field type that you're using for
-    the field interpolation.  So for particle-based codes, this must be the
-    ftype of the gas particles (e.g., `PartType0`, `Gas`).  Using the
-    default of `gas` in this instance will interpolate on the grid-based
-    fields, which will give the wrong answers for particle-based codes,
-    since the ion field interpolation will take place on the already
-    deposited grid-based fields.
-
     **Parameters**
 
     :ds: yt dataset object
@@ -199,14 +191,6 @@ def add_ion_fields(ds, ions, ftype='gas',
             (ie hydrogen to zinc).  If set to 'all' with ``line_database``
             keyword set, then creates **all** ions associated with the lines
             specified in the equivalent :class:`~trident.LineDatabase`.
-
-    :ftype: string, optional
-
-        The field type of the field to add.  it is the first string in the 
-        field tuple e.g. "gas" in ("gas", "O_p5_ion_fraction")
-        ftype must correspond to the ftype of the 'density', and 'temperature'
-        fields in your dataset you wish to use to generate the ion field.
-        Default: "gas"
 
     :ionization_table: string, optional
 
@@ -235,20 +219,20 @@ def add_ion_fields(ds, ions, ftype='gas',
         remain untouched.
         Default: False
 
+    :ftype: string, optional
+
+        This is deprecated and no longer necessary since all relevant 
+        fields are aliased to the 'gas' ftype.
+        Default: 'gas'
+
     :sampling_type: string, optional
 
-        Set to 'particle' if the field should be for particles.
-        Set to 'cell' if the field should be for grids/cells.
-        Set to 'auto' for this to be determined automatically.
-        Default: 'auto'
+        This is deprecated and no longer necessary.
+        Default: 'local'
 
     :particle_type: boolean, optional
 
-        This is deprecated in favor of 'sampling_type'.
-        Set to True if you are adding ion fields to particles, as specified
-        by the 'ftype'.  Set to False if you are not.  Set to 'auto', if
-        you want the code to autodetermine if the field specified by the
-        'ftype' is particle or not.
+        This is deprecated and no longer necessary.
         Default: 'auto'
 
     **Example**
@@ -301,9 +285,8 @@ def add_ion_fields(ds, ions, ftype='gas',
     # - X_P#_number_density
     # - X_P#_density
     for (atom, ion) in ion_list:
-        add_ion_mass_field(atom, ion, ds, ftype, ionization_table,
-            field_suffix=field_suffix, force_override=force_override, 
-            sampling_type=sampling_type)
+        add_ion_mass_field(atom, ion, ds, ionization_table,
+            field_suffix=field_suffix, force_override=force_override)
 
 def add_ion_fraction_field(atom, ion, ds, ftype="gas",
                            ionization_table=None,
@@ -327,14 +310,6 @@ def add_ion_fraction_field(atom, ion, ds, ftype="gas",
     photoionization in the optically thin limit from a redshift-dependent
     metagalactic ionizing background using the ionization_table specified.
 
-    **WARNING**: The "ftype" must match the field type that you're using for
-    the field interpolation.  So for particle-based codes, this must be the
-    ftype of the gas particles (e.g., `PartType0`, `Gas`).  Using the
-    default of `gas` in this instance will interpolate on the grid-based
-    fields, which will give the wrong answers for particle-based codes,
-    since the ion field interpolation will take place on the already
-    deposited grid-based fields.
-
     **Parameters**
 
     :atom: string
@@ -348,11 +323,10 @@ def add_ion_fraction_field(atom, ion, ds, ftype="gas",
         This is the dataset to which the ion fraction field will be added.
 
     :ftype: string, optional
-        The field type of the field to add.  it is the first string in the 
-        field tuple e.g. "gas" in ("gas", "O_p5_ion_fraction")
-        ftype must correspond to the ftype of the 'density', and 'temperature'
-        fields in your dataset you wish to use to generate the ion field.
-        Default: "gas"
+
+        This is deprecated and no longer necessary since all relevant 
+        fields are aliased to the 'gas' ftype.
+        Default: 'gas'
 
     :ionization_table: string, optional
         Path to an appropriately formatted HDF5 table that can be used to 
@@ -373,18 +347,12 @@ def add_ion_fraction_field(atom, ion, ds, ftype="gas",
 
     :sampling_type: string, optional
 
-        Set to 'particle' if the field should be for particles.
-        Set to 'cell' if the field should be for grids/cells.
-        Set to 'auto' for this to be determined automatically.
-        Default: 'auto'
+        This is deprecated and no longer necessary.
+        Default: 'local'
 
     :particle_type: boolean, optional
 
-        This is deprecated in favor of 'sampling_type'.
-        Set to True if you are adding ion fields to particles, as specified
-        by the 'ftype'.  Set to False if you are not.  Set to 'auto', if
-        you want the code to autodetermine if the field specified by the
-        'ftype' is particle or not.
+        This is deprecated and no longer necessary.
         Default: 'auto'
 
     **Example**
@@ -475,14 +443,6 @@ def add_ion_number_density_field(atom, ion, ds, ftype="gas",
     photoionization in the optically thin limit from a redshift-dependent
     metagalactic ionizing background using the ionization_table specified.
 
-    **WARNING**: The "ftype" must match the field type that you're using for
-    the field interpolation.  So for particle-based codes, this must be the
-    ftype of the gas particles (e.g., `PartType0`, `Gas`).  Using the
-    default of `gas` in this instance will interpolate on the grid-based
-    fields, which will give the wrong answers for particle-based codes,
-    since the ion field interpolation will take place on the already
-    deposited grid-based fields.
-
     **Parameters**
 
     :atom: string
@@ -500,11 +460,9 @@ def add_ion_number_density_field(atom, ion, ds, ftype="gas",
 
     :ftype: string, optional
 
-        The field type of the field to add.  it is the first string in the 
-        field tuple e.g. "gas" in ("gas", "O_p5_ion_fraction")
-        ftype must correspond to the ftype of the 'density', and 'temperature'
-        fields in your dataset you wish to use to generate the ion field.
-        Default: "gas"
+        This is deprecated and no longer necessary since all relevant 
+        fields are aliased to the 'gas' ftype.
+        Default: 'gas'
 
     :ionization_table: string, optional
 
@@ -527,18 +485,12 @@ def add_ion_number_density_field(atom, ion, ds, ftype="gas",
 
     :sampling_type: string, optional
 
-        Set to 'particle' if the field should be for particles.
-        Set to 'cell' if the field should be for grids/cells.
-        Set to 'auto' for this to be determined automatically.
-        Default: 'auto'
+        This is deprecated and no longer necessary.
+        Default: 'local'
 
     :particle_type: boolean, optional
 
-        This is deprecated in favor of 'sampling_type'.
-        Set to True if you are adding ion fields to particles, as specified
-        by the 'ftype'.  Set to False if you are not.  Set to 'auto', if
-        you want the code to autodetermine if the field specified by the
-        'ftype' is particle or not.
+        This is deprecated and no longer necessary.
         Default: 'auto'
 
     **Example**
@@ -611,14 +563,6 @@ def add_ion_density_field(atom, ion, ds, ftype="gas",
     photoionization in the optically thin limit from a redshift-dependent
     metagalactic ionizing background using the ionization_table specified.
 
-    **WARNING**: The "ftype" must match the field type that you're using for
-    the field interpolation.  So for particle-based codes, this must be the
-    ftype of the gas particles (e.g., `PartType0`, `Gas`).  Using the
-    default of `gas` in this instance will interpolate on the grid-based
-    fields, which will give the wrong answers for particle-based codes,
-    since the ion field interpolation will take place on the already
-    deposited grid-based fields.
-
     **Parameters**
 
     :atom: string
@@ -636,11 +580,9 @@ def add_ion_density_field(atom, ion, ds, ftype="gas",
 
     :ftype: string, optional
 
-        The field type of the field to add.  it is the first string in the 
-        field tuple e.g. "gas" in ("gas", "O_p5_ion_fraction")
-        ftype must correspond to the ftype of the 'density', and 'temperature'
-        fields in your dataset you wish to use to generate the ion field.
-        Default: "gas"
+        This is deprecated and no longer necessary since all relevant 
+        fields are aliased to the 'gas' ftype.
+        Default: 'gas'
 
     :ionization_table: string, optional
 
@@ -663,18 +605,12 @@ def add_ion_density_field(atom, ion, ds, ftype="gas",
 
     :sampling_type: string, optional
 
-        Set to 'particle' if the field should be for particles.
-        Set to 'cell' if the field should be for grids/cells.
-        Set to 'auto' for this to be determined automatically.
-        Default: 'auto'
+        This is deprecated and no longer necessary.
+        Default: 'local'
 
     :particle_type: boolean, optional
 
-        This is deprecated in favor of 'sampling_type'.
-        Set to True if you are adding ion fields to particles, as specified
-        by the 'ftype'.  Set to False if you are not.  Set to 'auto', if
-        you want the code to autodetermine if the field specified by the
-        'ftype' is particle or not.
+        This is deprecated and no longer necessary.
         Default: 'auto'
 
     **Example**
@@ -774,11 +710,9 @@ def add_ion_mass_field(atom, ion, ds, ftype="gas",
 
     :ftype: string, optional
 
-        The field type of the field to add.  it is the first string in the 
-        field tuple e.g. "gas" in ("gas", "O_p5_ion_fraction")
-        ftype must correspond to the ftype of the 'density', and 'temperature'
-        fields in your dataset you wish to use to generate the ion field.
-        Default: "gas"
+        This is deprecated and no longer necessary since all relevant 
+        fields are aliased to the 'gas' ftype.
+        Default: 'gas'
 
     :ionization_table: string, optional
 
@@ -801,18 +735,12 @@ def add_ion_mass_field(atom, ion, ds, ftype="gas",
 
     :sampling_type: string, optional
 
-        Set to 'particle' if the field should be for particles.
-        Set to 'cell' if the field should be for grids/cells.
-        Set to 'auto' for this to be determined automatically.
-        Default: 'auto'
+        This is deprecated and no longer necessary.
+        Default: 'local'
 
     :particle_type: boolean, optional
 
-        This is deprecated in favor of 'sampling_type'.
-        Set to True if you are adding ion fields to particles, as specified
-        by the 'ftype'.  Set to False if you are not.  Set to 'auto', if
-        you want the code to autodetermine if the field specified by the
-        'ftype' is particle or not.
+        This is deprecated and no longer necessary.
         Default: 'auto'
 
     **Example**

--- a/trident/ion_balance.py
+++ b/trident/ion_balance.py
@@ -92,6 +92,12 @@ def _log_nH(field, data):
     """
     One index of ion balance table is in log of density, so this translates
     dataset's density values into the same format for indexing the table
+
+    N.B. All datasets *should* have an H_nuclei_density field defined if
+    created in the standard way in yt.  Ray objects will also include
+    H_nuclei_density from the parent dataset to assure identical behavior
+    when ions are added to a ray as when they are added to an original dataset
+    before then being included in a ray.
     """
     if ("gas", "H_nuclei_density") in data.ds.derived_field_list:
         log_nH_field = np.log10(data["gas", "H_nuclei_density"])
@@ -103,6 +109,13 @@ def _redshift(field, data):
     """
     One index of ion balance table is in redshift, so this translates
     dataset's redshift values into the same format for indexing the table
+
+    Note that if there already exists a "redshift" field on the dataset (e.g.,
+    on a LightRay dataset), that redshift field will be used instead.  This can 
+    lead to slight differences (1 part in 1e8) in the calculation of ion fields 
+    when added to a LightRay than when added to a dataset because redshift
+    is continually varying (slightly) along the ray, whereas it is fixed for
+    a standard dataset.
     """
     # Assure that redshift is defined for dataset--if not, assume z=0
     try:

--- a/trident/ray_generator.py
+++ b/trident/ray_generator.py
@@ -200,6 +200,9 @@ def make_simple_ray(dataset_file, start_position, end_position,
     if ionization_table is None:
         ionization_table = ion_table_filepath
 
+    # Include some default fields in the ray to assure it's processed correctly.
+    fields = _add_default_fields(ds, fields)
+
     # If 'lines' kwarg is set, we need to get all the fields required to
     # create the desired absorption lines in the grid format, since grid-based
     # fields are what are directly probed by the LightRay object.  
@@ -584,3 +587,17 @@ def _determine_fields_from_ions(ds, ion_list, fields):
     fields.append(("gas", 'temperature'))
 
     return fields, fields_to_add_to_ds
+
+def _add_default_fields(ds, fields): 
+    """ 
+    Add some default fields to rays to assure they can be processed correctly.
+    """
+    if ("gas", "temperature") in ds.derived_field_list:
+        fields.append(("gas", 'temperature'))
+
+    # H_nuclei_density should be added if possible to assure that the _log_nH
+    # field, which is used as "density" in the ion_balance interpolation to 
+    # produce ion fields, is calculated as accurately as possible.
+    if ('gas', 'H_nuclei_density') in ds.derived_field_list:
+        fields.append(('gas', 'H_nuclei_density'))
+    return fields

--- a/trident/ray_generator.py
+++ b/trident/ray_generator.py
@@ -74,11 +74,6 @@ def make_simple_ray(dataset_file, start_position, end_position,
     If the necessary fields do not exist for your line of choice, they will
     be added to your dataset before adding them to the ray.  
 
-    If using the :lines: keyword with an SPH dataset, it is very important
-    to set the :ftype: keyword appropriately, or you may end up calculating 
-    ion fields by interpolating on data already smoothed to the grid.  This is
-    generally not desired.
-    
     **Parameters**
 
     :dataset_file: string or yt Dataset object
@@ -93,11 +88,6 @@ def make_simple_ray(dataset_file, start_position, end_position,
         ray.  If providing a raw list, coordinates are assumed to be in 
         code length units, but if providing a YTArray, any units can be
         specified.
-                    lines=None, fields=None, solution_filename=None, 
-                    data_filename=None, trajectory=None, redshift=None, 
-                    line_database=None, ftype="gas", 
-                    setup_function=None, load_kwargs=None,
-                    ionization_table=None):
 
     :lines: list of strings, optional
 
@@ -107,22 +97,11 @@ def make_simple_ray(dataset_file, start_position, end_position,
         the integer wavelength value of the desired line.  If set to 'all',
         includes all possible ions from H to Zn. :lines: can be used
         in conjunction with :fields: as they will not override each other.
-        If using the :lines: keyword with an SPH dataset, it is very important
-        to set the :ftype: keyword appropriately, or you may end up calculating 
-        ion fields by interpolating on data already smoothed to the grid.  
-        This is generally not desired.
         Default: None
 
     :ftype: string, optional
 
-        For use with the :lines: keyword.  It is the field type of the fields to 
-        be added.  It is the first string in the field tuple e.g. "gas" in
-        ("gas", "O_p5_number_density"). For SPH datasets, it is important to
-        set this to the field type of the gas particles in your dataset
-        (e.g. 'PartType0'), as it determines the source data for the ion 
-        fields to be added. If you leave it set to "gas", it will calculate 
-        the ion fields based on the hydro fields already smoothed on the grid, 
-        which is usually not desired.
+        This is now deprecated and unnecessary.
         Default: "gas"
 
     :fields: list of strings, optional
@@ -195,15 +174,14 @@ def make_simple_ray(dataset_file, start_position, end_position,
     **Example**
 
     Generate a simple ray passing from the lower left corner to the upper 
-    right corner through some Gizmo dataset where gas particles are 
-    ftype='PartType0':
+    right corner through some Gizmo dataset:
 
     >>> import trident
     >>> import yt
     >>> ds = yt.load('path/to/dataset')
     >>> ray = trident.make_simple_ray(ds, 
     ... start_position=ds.domain_left_edge, end_position=ds.domain_right_edge,
-    ... lines=['H', 'O', 'Mg II'], ftype='PartType0')
+    ... lines=['H', 'O', 'Mg II'])
     """
     if load_kwargs is None:
         load_kwargs = {}
@@ -234,17 +212,12 @@ def make_simple_ray(dataset_file, start_position, end_position,
 
         ion_list = _determine_ions_from_lines(line_database, lines)
 
-        sampling_type = "local"
-
         fields, fields_to_add_to_ds = _determine_fields_from_ions(ds, ion_list, 
-                                        fields, ftype, sampling_type)
-
+                                        fields)
         # actually add the fields we need to add to the dataset
         for atom, ion_state in fields_to_add_to_ds:
             add_ion_number_density_field(atom, ion_state, ds, 
-                                         ftype=ftype,
-                                         ionization_table=ionization_table,
-                                         sampling_type=sampling_type)
+                                         ionization_table=ionization_table)
 
     # To assure there are no fields that are double specified or that collide
     # based on being specified as "density" as well as ("gas", "density"), 
@@ -279,7 +252,7 @@ def make_compound_ray(parameter_filename, simulation_type,
     .. note::
         
         The compound ray functionality has only been implemented for the
-        Enzo and Gadget code.  If you would like to help us implement
+        Enzo and Gadget/Gizmo codes.  If you would like to help us implement
         this functionality for your simulation code, please contact us
         about this on the mailing list.
 
@@ -328,11 +301,6 @@ def make_compound_ray(parameter_filename, simulation_type,
     If the necessary fields do not exist for your line of choice, they will
     be added to your datasets before adding them to the ray.  
 
-    If using the :lines: keyword with SPH datasets, it is very important
-    to set the :ftype: keyword appropriately, or you may end up calculating 
-    ion fields by interpolating on data already smoothed to the grid.  This is
-    generally not desired.
- 
     **Parameters**
 
     :parameter_filename: string
@@ -357,22 +325,11 @@ def make_compound_ray(parameter_filename, simulation_type,
         the integer wavelength value of the desired line.  If set to 'all',
         includes all possible ions from H to Zn. :lines: can be used
         in conjunction with :fields: as they will not override each other.
-        If using the :lines: keyword with an SPH dataset, it is very important
-        to set the :ftype: keyword appropriately, or you may end up calculating 
-        ion fields by interpolating on data already smoothed to the grid.  
-        This is generally not desired.
         Default: None
 
     :ftype: string, optional
 
-        For use with the :lines: keyword.  It is the field type of the fields to 
-        be added.  It is the first string in the field tuple e.g. "gas" in
-        ("gas", "O_p5_number_density"). For SPH datasets, it is important to
-        set this to the field type of the gas particles in your dataset
-        (e.g. 'PartType0'), as it determines the source data for the ion 
-        fields to be added. If you leave it set to "gas", it will calculate 
-        the ion fields based on the hydro fields already smoothed on the grid, 
-        which is usually not desired.
+        This is now deprecated and unnecessary.
         Default: "gas"
 
     :fields: list of strings, optional
@@ -467,8 +424,7 @@ def make_compound_ray(parameter_filename, simulation_type,
     >>> import trident
     >>> fn = 'path/to/simulation/parameter/file'
     >>> ray = trident.make_compound_ray(fn, simulation_type='Enzo',
-    ... near_redshift=0.0, far_redshift=0.05, ftype='gas',
-    ... lines=['H', 'O', 'Mg II'])
+    ... near_redshift=0.0, far_redshift=0.05, lines=['H', 'O', 'Mg II'])
 
     Generate a compound ray passing from the redshift 0 to redshift 0.05
     through a multi-output gadget simulation.
@@ -476,8 +432,7 @@ def make_compound_ray(parameter_filename, simulation_type,
     >>> import trident
     >>> fn = 'path/to/simulation/parameter/file'
     >>> ray = trident.make_compound_ray(fn, simulation_type='Gadget',
-    ... near_redshift=0.0, far_redshift=0.05,
-    ... lines=['H', 'O', 'Mg II'], ftype='PartType0')
+    ... near_redshift=0.0, far_redshift=0.05, lines=['H', 'O', 'Mg II'])
     """
     if load_kwargs is None:
         load_kwargs = {}
@@ -506,11 +461,10 @@ def make_compound_ray(parameter_filename, simulation_type,
     # inspect the dataset to see if they already exist.  If so, we add them
     # to the field list for the ray.  If not, we have to create them.
 
-    # We use the final dataset from the simulation in order to test it for 
-    # the sampling_type of the field, what fields are present, etc.  This 
-    # all assumes that the fields present in this output will be present in 
-    # ALL outputs.  Hopefully this is true, because testing each dataset
-    # is going to be slow and a pain.
+    # We use the final dataset from the simulation in order to test it for
+    # what fields are present, etc.  This all assumes that the fields present
+    # in this output will be present in ALL outputs.  Hopefully this is true,
+    # because testing each dataset is going to be slow and a pain.
 
     if lines is not None:
 
@@ -520,10 +474,8 @@ def make_compound_ray(parameter_filename, simulation_type,
 
         ion_list = _determine_ions_from_lines(line_database, lines)
 
-        sampling_type = "local"
-
         fields, fields_to_add_to_ds = _determine_fields_from_ions(ds, ion_list, 
-                                        fields, ftype, sampling_type)
+                                        fields)
 
         # actually add the fields we need to add to the dataset
         # by adding the fields to the setup_function passed to each dataset
@@ -533,9 +485,7 @@ def make_compound_ray(parameter_filename, simulation_type,
 
             for atom, ion_state in fields_to_add_to_ds:
                 add_ion_number_density_field(atom, ion_state, ds, 
-                                            ftype=ftype,
-                                            ionization_table=ionization_table,
-                                            sampling_type=sampling_type)
+                                            ionization_table=ionization_table)
             if setup_function is not None:
                 setup_function(ds)
 
@@ -587,22 +537,10 @@ def _determine_ions_from_lines(line_database, lines):
 
     return uniquify(ion_list)        
 
-def _determine_fields_from_ions(ds, ion_list, fields, ftype, sampling_type):
+def _determine_fields_from_ions(ds, ion_list, fields):
     """
-    Figure out what fields need to be added based on the ions present
-    and the particle type
+    Figure out what fields need to be added based on the ions present.
 
-    For sph (determined by sampling_type):
-    Identify if the number_density fields for the desired ions already 
-    exist on the dataset, and if so, just add them to the list
-    of fields to be added to the ray.
-    If not, add these ion fields to the dataset as particle fields, 
-    which prompts them being smoothed to the grid, and add the resulting 
-    smoothed fields (e.g. ("gas", "x_number_density")) to the list of fields 
-    to be added to the ray.  Include the 'temperature' field for 
-    calculating the width of voigt profiles in the absorption spectrum.
-
-    For grid:
     Check if the number_density fields for these ions exist, and if so, add 
     them to field list. If not, leave them off, as they'll be generated 
     on the fly by SpectrumGenerator as long as we include the 'density',
@@ -625,27 +563,23 @@ def _determine_fields_from_ions(ds, ion_list, fields, ftype, sampling_type):
         # This is ugly, but I couldn't find a way around it to hit
         # all 6 cases of when fields were present or not and particle
         # type or not.
-        if (ftype, field) not in ds.derived_field_list:
-            if (ftype, alias_field) not in ds.derived_field_list:
-                if sampling_type == 'particle':
-                    fields_to_add_to_ds.append((atom, ion_state))
-                    fields.append(("gas", alias_field))
+        if ("gas", field) not in ds.derived_field_list:
+            if ("gas", alias_field) not in ds.derived_field_list:
+                # If the ion field 
+                # doesn't yet exist, just append the density and 
+                # appropriate metal field for ion field calculation 
+                # on the ray itself instead of adding it to the full ds
+                fields.append(('gas', 'density'))
+                if ('gas', metallicity_field) in ds.derived_field_list:
+                    fields.append(('gas', metallicity_field))
+                elif ('gas', nuclei_field) in ds.derived_field_list:
+                    fields.append(('gas', nuclei_field))
+                elif atom != 'H':
+                    fields.append(('gas', 'metallicity'))
                 else:
-                    # If this is a  grid-based field where the ion field 
-                    # doesn't yet exist, just append the density and 
-                    # appropriate metal field for ion field calculation 
-                    # on the ray itself instead of adding it to the full ds
-                    fields.append(('gas', 'density'))
-                    if ('gas', metallicity_field) in ds.derived_field_list:
-                        fields.append(('gas', metallicity_field))
-                    elif ('gas', nuclei_field) in ds.derived_field_list:
-                        fields.append(('gas', nuclei_field))
-                    elif atom != 'H':
-                        fields.append(('gas', 'metallicity'))
-                    else:
-                        # Don't need metallicity field if we're just looking
-                        # at hydrogen
-                        pass
+                    # Don't need metallicity field if we're just looking
+                    # at hydrogen
+                    pass
             else:
                 fields.append(("gas", alias_field))
         else:

--- a/trident/ray_generator.py
+++ b/trident/ray_generator.py
@@ -560,15 +560,12 @@ def _determine_fields_from_ions(ds, ion_list, fields):
             field = "%s_p%d_number_density" % (atom, ion_state-1)
             alias_field = "%s_p%d_number_density" % (atom, ion_state-1)
 
-        # This is ugly, but I couldn't find a way around it to hit
-        # all 6 cases of when fields were present or not and particle
-        # type or not.
+        # Check to see if the ion field (or its alias) exists.  If so, add 
+        # it to the ray.  If not, then append the density and the appropriate
+        # metal field so one can create the ion field on the fly on the 
+        # ray itself.
         if ("gas", field) not in ds.derived_field_list:
             if ("gas", alias_field) not in ds.derived_field_list:
-                # If the ion field 
-                # doesn't yet exist, just append the density and 
-                # appropriate metal field for ion field calculation 
-                # on the ray itself instead of adding it to the full ds
                 fields.append(('gas', 'density'))
                 if ('gas', metallicity_field) in ds.derived_field_list:
                     fields.append(('gas', metallicity_field))

--- a/trident/ray_generator.py
+++ b/trident/ray_generator.py
@@ -584,7 +584,6 @@ def _determine_fields_from_ions(ds, ion_list, fields):
                 fields.append(("gas", alias_field))
         else:
             fields.append(("gas", field))
-    fields.append(("gas", 'temperature'))
 
     return fields, fields_to_add_to_ds
 
@@ -600,4 +599,5 @@ def _add_default_fields(ds, fields):
     # produce ion fields, is calculated as accurately as possible.
     if ('gas', 'H_nuclei_density') in ds.derived_field_list:
         fields.append(('gas', 'H_nuclei_density'))
+
     return fields

--- a/trident/ray_generator.py
+++ b/trident/ray_generator.py
@@ -201,6 +201,7 @@ def make_simple_ray(dataset_file, start_position, end_position,
         ionization_table = ion_table_filepath
 
     # Include some default fields in the ray to assure it's processed correctly.
+
     fields = _add_default_fields(ds, fields)
 
     # If 'lines' kwarg is set, we need to get all the fields required to
@@ -214,7 +215,6 @@ def make_simple_ray(dataset_file, start_position, end_position,
     if lines is not None:
 
         ion_list = _determine_ions_from_lines(line_database, lines)
-
         fields = _determine_fields_from_ions(ds, ion_list, fields)
 
     # To assure there are no fields that are double specified or that collide
@@ -449,27 +449,30 @@ def make_compound_ray(parameter_filename, simulation_type,
     if ionization_table is None:
         ionization_table = ion_table_filepath
 
+    # We use the final dataset from the simulation in order to test it for
+    # what fields are present, etc.  This all assumes that the fields present
+    # in this output will be present in ALL outputs.  Hopefully this is true,
+    # because testing each dataset is going to be slow and a pain.
+
+    sim = simulation(parameter_filename, simulation_type)
+    ds = load(sim.all_outputs[-1]['filename'])
+
+    # Include some default fields in the ray to assure it's processed correctly.
+
+    fields = _add_default_fields(ds, fields)
+
     # If 'lines' kwarg is set, we need to get all the fields required to
     # create the desired absorption lines in the grid format, since grid-based
     # fields are what are directly probed by the LightRay object.  
 
     # We first determine what fields are necessary for the desired lines, and
     # inspect the dataset to see if they already exist.  If so, we add them
-    # to the field list for the ray.  If not, we have to create them.
-
-    # We use the final dataset from the simulation in order to test it for
-    # what fields are present, etc.  This all assumes that the fields present
-    # in this output will be present in ALL outputs.  Hopefully this is true,
-    # because testing each dataset is going to be slow and a pain.
+    # to the field list for the ray or add the necessary fields that can
+    # generate them on the ray.  
 
     if lines is not None:
 
-        # load the final dataset from the simulation to use for testing
-        sim = simulation(parameter_filename, simulation_type)
-        ds = load(sim.all_outputs[-1]['filename'])
-
         ion_list = _determine_ions_from_lines(line_database, lines)
-
         fields = _determine_fields_from_ions(ds, ion_list, fields)
 
     # To assure there are no fields that are double specified or that collide

--- a/trident/utilities.py
+++ b/trident/utilities.py
@@ -32,8 +32,6 @@ from yt import \
     load_uniform_grid, \
     YTArray, \
     load
-from yt.geometry.particle_geometry_handler import \
-    ParticleIndex
 from yt.funcs import \
     mylog
 


### PR DESCRIPTION
With the new demeshened version of yt/trident, we shouldn't have to worry about `sampling_type` or `ftype` anymore, which greatly simplfies the execution of adding ion fields.  This PR unifies the treatment of grid-based and particle-based datasets in Trident by assuming all `ftype='gas'` and `sampling_type='local'` throughout the codebase.  This assumption should work since all relevant gas fields will be aliased to the `'gas'` ftype and `sampling_type` is now defined as `'local'` instead of `'cell'` and `'particle'`.  

That said, I am still seeing different behavior when I add ion fields to a dataset and then sample it with a `LightRay` versus when I create a `LightRay` and generate the ion fields on that dataset on the fly.  This should not happen, and until that is addressed this PR should not be merged.

For reference, this is the script that demonstrates the problematic behavior:

```
# There appears to be a difference in the added ion fields when you calculate
# them on the underlying dataset versus when you calculate them on the fly
# on a LightRay object.  It seems like this should not be the case under
# the new demeshening since both will use the same density values the same
# metallicity values

import yt
import trident
# Send a ray through the densest region of a sim to the edge.
#fn = 'IsolatedGalaxy/galaxy0030/galaxy0030'  # Identical values below for AMR
fn = 'FIRE_M12i_ref11/snapshot_600.hdf5'     # Diff values below for SPH
ds = yt.load(fn)
_, c = ds.find_max(('gas', 'density'))
ray_start = c
ray_end = ds.domain_right_edge

# Create a ray and make sure it has fields necessary to generate C II fields
# on the ray (i.e., density, C_metallicity); Then add the C II ion fraction
# field on the ray itself.
ray1 = trident.make_simple_ray(ds, start_position=ray_start,
                              end_position=ray_end, data_filename='ray1.h5',
                              fields=[('gas', 'C_metallicity'), ('gas', 'density')])
trident.add_ion_fraction_field('C', 2, ray1)

# Now just add C II to the underlying dataset and sample it along the ray
# directly instead of calculating it on the ray on the fly as above.
trident.add_ion_fraction_field('C', 2, ds)
ray2 = trident.make_simple_ray(ds, start_position=ray_start,
                              end_position=ray_end, data_filename='ray2.h5',
                              fields=[('gas', 'C_p1_ion_fraction')])

# Are the two methods equal?! No, but why?
ad1 = ray1.all_data()
ad2 = ray2.all_data()
print(ad1[('gas', 'C_p1_ion_fraction')].max())
print(ad2[('gas', 'C_p1_ion_fraction')].max())
```