### PR TITLE
Cache test answers and only generate if they don't exist.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ cache:
     - $HOME/.ccache  # https://github.com/travis-ci/travis-ci/issues/5853
     - $YT_DIR
     - $TRIDENT_ION_DATA
+    - $TRIDENT_ANSWER_DATA
   pip: true
 
 addons:
@@ -78,15 +79,18 @@ before_script:
 
 script:
   - |
+    export RUN_DOWNLOAD_TEST=0
     # install gold standard and generate answers
     # this uses the yt gold standard version
-    export RUN_DOWNLOAD_TEST=0
-    export TRIDENT_GENERATE_TEST_RESULTS=1
-    git checkout $TRIDENT_GOLD
-    pip install -e .
-    pushd tests
-    py.test
-    popd
+    # answers are cached, so don't generate if they already exist
+    if [ ! -f $TRIDENT_ANSWER_DATA/test_results/TRIDENT_VERSION ]; then
+        export TRIDENT_GENERATE_TEST_RESULTS=1
+        git checkout $TRIDENT_GOLD
+        pip install -e .
+        pushd tests
+        py.test
+        popd
+    fi
     # gold-standard yt + trident tip
     export TRIDENT_GENERATE_TEST_RESULTS=0
     git checkout HEAD


### PR DESCRIPTION
This should cut down the run time and the number of cron tests hitting the time limit.