### PR TITLE
Removing yt-dev + trident-stable testing loop to reduce testing time.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -106,8 +106,3 @@ script:
     pushd tests
     py.test
     popd
-    # yt tip + trident gold standard
-    git checkout $TRIDENT_GOLD
-    pip install -e .
-    pushd tests
-    py.test


### PR DESCRIPTION
Hopefully this resolves the tests going over the time limit and failing intermittently.