### PR TITLE
Updated trident_path() to be OS Independent

### DIFF
--- a/trident/config.py
+++ b/trident/config.py
@@ -52,9 +52,10 @@ def trident_path():
 
     >>> print(trident_path())
     """
-    path_list = os.path.dirname(__file__).split('/')[:-1]
-    path_list.append('trident')
-    return '/'.join(path_list)
+    # os.path.split(__file__)returns a tuple with [0] the path to the file 
+    # and [1] the filename.
+    # Here, __file__ refers to this file (config.py)
+    return os.path.split(__file__)[0]
 
 def create_config():
     """


### PR DESCRIPTION
Previous implementation used to get the `dirname` of `__file__`, split that using `/`, exclude last element, append `trident` to this list and join all elements. The split operation using `/` is *platform dependent* and breaks on Windows. One Fix is to use the current approach but substitute `/` with `os.path.sep` but the whole operation can be streamlined to one command.