### PR TITLE
Updating master branch with bugfixes applied to sph-viz in the last two months

### DIFF
--- a/trident/absorption_spectrum/absorption_spectrum.py
+++ b/trident/absorption_spectrum/absorption_spectrum.py
@@ -401,6 +401,11 @@ class AbsorptionSpectrum(object):
         # low column density absorbers can add up to a significant
         # continuum effect, we normalize min_tau by the n_absorbers.
         n_absorbers = field_data['dl'].size
+
+        if n_absorbers == 0:
+            mylog.info("No absorbers in path of LightRay.")
+            return
+
         min_tau /= n_absorbers
 
         for continuum in self.continuum_list:

--- a/trident/ion_balance.py
+++ b/trident/ion_balance.py
@@ -452,9 +452,9 @@ def add_ion_fraction_field(atom, ion, ds, ftype="gas",
     else:
         field = "%s_p%d_ion_fraction" % (atom, ion-1)
     if field_suffix:
-        field += "_%s" % ionization_table.split("/")[-1].split(".h5")[0]
+        field += "_%s" % ionization_table.split(os.sep)[-1].split(".h5")[0]
         if ion == 1:
-            alias_field += "_%s" % ionization_table.split("/")[-1].split(".h5")[0]
+            alias_field += "_%s" % ionization_table.split(os.sep)[-1].split(".h5")[0]
 
     if not field in table_store:
         ionTable = IonBalanceTable(ionization_table, atom)
@@ -590,9 +590,9 @@ def add_ion_number_density_field(atom, ion, ds, ftype="gas",
     else:
         field = "%s_p%d_number_density" % (atom, ion-1)
     if field_suffix:
-        field += "_%s" % ionization_table.split("/")[-1].split(".h5")[0]
+        field += "_%s" % ionization_table.split(os.sep)[-1].split(".h5")[0]
         if ion == 1:
-            alias_field += "_%s" % ionization_table.split("/")[-1].split(".h5")[0]
+            alias_field += "_%s" % ionization_table.split(os.sep)[-1].split(".h5")[0]
 
     add_ion_fraction_field(atom, ion, ds, ftype, ionization_table,
                            field_suffix=field_suffix, 
@@ -728,9 +728,9 @@ def add_ion_density_field(atom, ion, ds, ftype="gas",
     else:
         field = "%s_p%d_density" % (atom, ion-1)
     if field_suffix:
-        field += "_%s" % ionization_table.split("/")[-1].split(".h5")[0]
+        field += "_%s" % ionization_table.split(os.sep)[-1].split(".h5")[0]
         if ion == 1:
-            alias_field += "_%s" % ionization_table.split("/")[-1].split(".h5")[0]
+            alias_field += "_%s" % ionization_table.split(os.sep)[-1].split(".h5")[0]
 
     add_ion_number_density_field(atom, ion, ds, ftype, ionization_table,
                                  field_suffix=field_suffix,
@@ -867,9 +867,9 @@ def add_ion_mass_field(atom, ion, ds, ftype="gas",
     else:
         field = "%s_p%s_mass" % (atom, ion-1)
     if field_suffix:
-        field += "_%s" % ionization_table.split("/")[-1].split(".h5")[0]
+        field += "_%s" % ionization_table.split(os.sep)[-1].split(".h5")[0]
         if ion == 1:
-            alias_field += "_%s" % ionization_table.split("/")[-1].split(".h5")[0]
+            alias_field += "_%s" % ionization_table.split(os.sep)[-1].split(".h5")[0]
 
     add_ion_density_field(atom, ion, ds, ftype, ionization_table,
                           field_suffix=field_suffix,

--- a/trident/ion_balance.py
+++ b/trident/ion_balance.py
@@ -94,6 +94,12 @@ def _log_nH(field, data):
     """
     One index of ion balance table is in log of density, so this translates
     dataset's density values into the same format for indexing the table
+
+    N.B. All datasets *should* have an H_nuclei_density field defined if
+    created in the standard way in yt.  Ray objects will also include
+    H_nuclei_density from the parent dataset to assure identical behavior
+    when ions are added to a ray as when they are added to an original dataset
+    before then being included in a ray.
     """
     if isinstance(field.name, tuple):
         ftype = field.name[0]
@@ -109,6 +115,13 @@ def _redshift(field, data):
     """
     One index of ion balance table is in redshift, so this translates
     dataset's redshift values into the same format for indexing the table
+
+    Note that if there already exists a "redshift" field on the dataset (e.g.,
+    on a LightRay dataset), that redshift field will be used instead.  This can 
+    lead to slight differences (1 part in 1e8) in the calculation of ion fields 
+    when added to a LightRay than when added to a dataset because redshift
+    is continually varying (slightly) along the ray, whereas it is fixed for
+    a standard dataset.
     """
     if isinstance(field.name, tuple):
         ftype = field.name[0]

--- a/trident/line_database.py
+++ b/trident/line_database.py
@@ -227,11 +227,11 @@ class LineDatabase:
         # if not, look in cwd
         filename = os.path.join(trident_path(), "data", "line_lists", filename)
         if not os.path.isfile(filename):
-            filename = filename.split('/')[-1]
+            filename = filename.split(os.sep)[-1]
         if not os.path.isfile(filename):
             raise RuntimeError("line_list %s is not found in local "
                                "directory or in trident/data/line_lists "
-                               % (filename.split('/')[-1]))
+                               % (filename.split(os.sep)[-1]))
 
         # Step through each line of text in file and add to database
         for line in open(filename).readlines():

--- a/trident/ray_generator.py
+++ b/trident/ray_generator.py
@@ -226,6 +226,7 @@ def make_simple_ray(dataset_file, start_position, end_position,
         ionization_table = ion_table_filepath
 
     # Include some default fields in the ray to assure it's processed correctly.
+
     fields = _add_default_fields(ds, fields)
 
     # If 'lines' kwarg is set, we need to get all the fields required to
@@ -517,6 +518,18 @@ def make_compound_ray(parameter_filename, simulation_type,
     if ionization_table is None:
         ionization_table = ion_table_filepath
 
+    # We use the final dataset from the simulation in order to test it for
+    # what fields are present, etc.  This all assumes that the fields present
+    # in this output will be present in ALL outputs.  Hopefully this is true,
+    # because testing each dataset is going to be slow and a pain.
+
+    sim = simulation(parameter_filename, simulation_type)
+    ds = load(sim.all_outputs[-1]['filename'])
+
+    # Include some default fields in the ray to assure it's processed correctly.
+
+    fields = _add_default_fields(ds, fields)
+
     # If 'lines' kwarg is set, we need to get all the fields required to
     # create the desired absorption lines in the grid format, since grid-based
     # fields are what are directly probed by the LightRay object.  
@@ -532,10 +545,6 @@ def make_compound_ray(parameter_filename, simulation_type,
     # is going to be slow and a pain.
 
     if lines is not None:
-
-        # load the final dataset from the simulation to use for testing
-        sim = simulation(parameter_filename, simulation_type)
-        ds = load(sim.all_outputs[-1]['filename'])
 
         ion_list = _determine_ions_from_lines(line_database, lines)
 

--- a/trident/ray_generator.py
+++ b/trident/ray_generator.py
@@ -669,7 +669,6 @@ def _determine_fields_from_ions(ds, ion_list, fields, ftype, sampling_type):
                 fields.append(("gas", alias_field))
         else:
             fields.append(("gas", field))
-    fields.append(("gas", 'temperature'))
 
     return fields, fields_to_add_to_ds
 
@@ -685,4 +684,5 @@ def _add_default_fields(ds, fields):
     # produce ion fields, is calculated as accurately as possible.
     if ('gas', 'H_nuclei_density') in ds.derived_field_list:
         fields.append(('gas', 'H_nuclei_density'))
+
     return fields

--- a/trident/ray_generator.py
+++ b/trident/ray_generator.py
@@ -225,6 +225,9 @@ def make_simple_ray(dataset_file, start_position, end_position,
     if ionization_table is None:
         ionization_table = ion_table_filepath
 
+    # Include some default fields in the ray to assure it's processed correctly.
+    fields = _add_default_fields(ds, fields)
+
     # If 'lines' kwarg is set, we need to get all the fields required to
     # create the desired absorption lines in the grid format, since grid-based
     # fields are what are directly probed by the LightRay object.  
@@ -669,3 +672,17 @@ def _determine_fields_from_ions(ds, ion_list, fields, ftype, sampling_type):
     fields.append(("gas", 'temperature'))
 
     return fields, fields_to_add_to_ds
+
+def _add_default_fields(ds, fields): 
+    """ 
+    Add some default fields to rays to assure they can be processed correctly.
+    """
+    if ("gas", "temperature") in ds.derived_field_list:
+        fields.append(("gas", 'temperature'))
+
+    # H_nuclei_density should be added if possible to assure that the _log_nH
+    # field, which is used as "density" in the ion_balance interpolation to 
+    # produce ion fields, is calculated as accurately as possible.
+    if ('gas', 'H_nuclei_density') in ds.derived_field_list:
+        fields.append(('gas', 'H_nuclei_density'))
+    return fields

--- a/trident/spectrum_generator.py
+++ b/trident/spectrum_generator.py
@@ -207,7 +207,7 @@ class SpectrumGenerator(AbsorptionSpectrum):
             else:
                 raise RuntimeError("ionization_table %s is not found in local "
                                    "directory or in %s" %
-                                   (filename.split('/')[-1],
+                                   (ion_table_file.split(os.sep)[-1],
                                     ion_table_dir))
         else:
             self.ionization_table = None

--- a/trident/utilities.py
+++ b/trident/utilities.py
@@ -95,7 +95,7 @@ def download_file(url, progress_bar=True, local_directory=None,
 
     # Set defaults
     if local_filename is None:
-        local_filename = url.split('/')[-1]
+        local_filename = url.split(os.sep)[-1]
     if local_directory is None:
         local_directory = '.'
     ensure_directory(local_directory)
@@ -464,8 +464,8 @@ def import_check():
     """
     """
     # Avoid astropy error when importing from trident package directory.
-    plist = os.path.dirname(os.path.abspath(__file__)).split('/')
-    package_path = '/'.join(plist[:-1])
+    plist = os.path.dirname(os.path.abspath(__file__)).split(os.sep)
+    package_path = os.sep.join(plist[:-1])
     if os.getcwd() == package_path:
         raise RuntimeError(
             """


### PR DESCRIPTION
The three main bugfixes are:

* Nathan's swapping out `os.sep` in lieu of `/` in filename separators
* A check to avoid failure when no continuum absorbers were found in the ray
* Auto-addition of `H_nuclei_density` to a `LightRay` when present in the base dataset, so as to assure that `log_nH` field (and thus all added ion fields) are the same on the `LightRay` as they are when added to the dataset directly.