### PR TITLE
Fix docs build warnings

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -34,6 +34,7 @@ import glob
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
+    'sphinx.ext.napoleon',
     'sphinx.ext.viewcode',
     'sphinx.ext.imgmath',
 ]

--- a/doc/source/help.rst
+++ b/doc/source/help.rst
@@ -39,7 +39,7 @@ out :ref:`here <what-version-am-i-running>`), and of course, a description of
 the problem you're having with any relevant traceback errors.  
 Our mailing list is located here::
 
-https://groups.google.com/forum/#!forum/trident-project-users 
+  https://groups.google.com/forum/#!forum/trident-project-users
 
 Join our Slack Channel
 ----------------------

--- a/trident/ray_generator.py
+++ b/trident/ray_generator.py
@@ -48,8 +48,8 @@ def make_simple_ray(dataset_file, start_position, end_position,
     """
     Create a yt LightRay object for a single dataset (eg CGM).  This is a 
     wrapper function around yt's LightRay interface to reduce some of the 
-    complexity there.  
-    
+    complexity there.
+
     A simple ray is a straight line passing through a single dataset
     where each gas cell intersected by the line is sampled for the desired
     fields and stored.  Several additional fields are created and stored
@@ -96,6 +96,7 @@ def make_simple_ray(dataset_file, start_position, end_position,
         ray.  If providing a raw list, coordinates are assumed to be in 
         code length units, but if providing a YTArray, any units can be
         specified.
+
                     lines=None, fields=None, solution_filename=None, 
                     data_filename=None, trajectory=None, redshift=None, 
                     line_database=None, ftype="gas", 


### PR DESCRIPTION
This adds the napolean sphinx extension to allow for proper rendering of numpy formatted (aka, the nice format) docstrings, of which we had a few. I also fixed a couple warnings. This would allow us to make a docs test on travis to make sure that the docs always build correctly.