### PR TITLE
Enabling use of `output_absorbers_file` kwarg in SpectrumGenerator

### DIFF
--- a/trident/absorption_spectrum/absorption_spectrum.py
+++ b/trident/absorption_spectrum/absorption_spectrum.py
@@ -195,6 +195,8 @@ class AbsorptionSpectrum(object):
 
            if True, stores observable properties of each cell along the line of
            sight for each line, such as tau, column density, and thermal b.
+           These quantities will be saved to the AbsorptionSpectrum
+           attribute: 'line_observables_dict'.
            Default: False
 
         :subgrid_resolution: optional, int

--- a/trident/spectrum_generator.py
+++ b/trident/spectrum_generator.py
@@ -217,6 +217,7 @@ class SpectrumGenerator(AbsorptionSpectrum):
 
     def make_spectrum(self, ray, lines='all',
                       output_file=None,
+                      output_absorbers_file=None,
                       use_peculiar_velocity=True,
                       observing_redshift=0.0,
                       ly_continuum=True,
@@ -252,6 +253,14 @@ class SpectrumGenerator(AbsorptionSpectrum):
             and everything else is ASCII.  Equivalent of calling
             :class:`~trident.SpectrumGenerator.save_spectrum`.
             Default: None
+
+        :output_absorbers_file: optional, string
+
+           Option to save a text file containing all of the absorbers and
+           corresponding wavelength and redshift information.
+           For parallel jobs, combining the lines lists can be slow so it
+           is recommended to set to None in such circumstances.
+           Default: None
 
         :use_peculiar_velocity: optional, bool
 
@@ -389,6 +398,7 @@ class SpectrumGenerator(AbsorptionSpectrum):
         AbsorptionSpectrum.make_spectrum(self, ray,
                                          output_file=None,
                                          line_list_file=None,
+                                         output_absorbers_file=output_absorbers_file,
                                          use_peculiar_velocity=use_peculiar_velocity,
                                          observing_redshift=observing_redshift,
                                          store_observables=store_observables,

--- a/trident/spectrum_generator.py
+++ b/trident/spectrum_generator.py
@@ -290,7 +290,7 @@ class SpectrumGenerator(AbsorptionSpectrum):
             ray will be saved for each line in the line list. Properties
             include the column density, tau, thermal b, and the wavelength
             where tau was deposited. Best applied for a reasonable number
-            of lines.  These quantities will be saved to the SpectrumGenerator 
+            of lines.  These quantities will be saved to the SpectrumGenerator
             attribute: 'line_observables_dict'.
             Default: False
 

--- a/trident/spectrum_generator.py
+++ b/trident/spectrum_generator.py
@@ -290,7 +290,8 @@ class SpectrumGenerator(AbsorptionSpectrum):
             ray will be saved for each line in the line list. Properties
             include the column density, tau, thermal b, and the wavelength
             where tau was deposited. Best applied for a reasonable number
-            of lines.
+            of lines.  These quantities will be saved to the SpectrumGenerator 
+            attribute: 'line_observables_dict'.
             Default: False
 
         :min_tau: optional, float


### PR DESCRIPTION
This functionality was requested by a user, so I am just allowing it to pass through to AbsorptionSpectrum.  I also added a helpful message to the docstring for the `store_observables` kwarg as to where the observables were actually stored.