### PR TITLE
Assuring Travis tests against yt dev tip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
     TRIDENT_ANSWER_DATA=$HOME/answer_test_data
     TRIDENT_CONFIG=$TRIDENT_ION_DATA/config.tri
     YT_GOLD=38b79c094ca9
-    YT_HEAD=refs/heads/master
+    YT_HEAD=master
     TRIDENT_GOLD=test-standard-v2
 
 before_install:
@@ -93,7 +93,6 @@ script:
     pip install -e .
     # relevant yt version
     pushd $YT_DIR
-    cat .git/HEAD
     git checkout $YT_VER
     pip install -e .
     popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ env:
     TRIDENT_ION_DATA=$HOME/.trident
     TRIDENT_ANSWER_DATA=$HOME/answer_test_data
     TRIDENT_CONFIG=$TRIDENT_ION_DATA/config.tri
-    # set to current gold standard and master head respectively
     YT_GOLD=38b79c094ca9
     YT_HEAD=refs/heads/master
     TRIDENT_GOLD=test-standard-v2

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,9 @@ env:
     TRIDENT_ION_DATA=$HOME/.trident
     TRIDENT_ANSWER_DATA=$HOME/answer_test_data
     TRIDENT_CONFIG=$TRIDENT_ION_DATA/config.tri
+    # set to current gold standard and master head respectively
     YT_GOLD=38b79c094ca9
+    YT_HEAD=refs/heads/master
     TRIDENT_GOLD=test-standard-v2
 
 before_install:
@@ -92,6 +94,7 @@ script:
     pip install -e .
     # relevant yt version
     pushd $YT_DIR
+    cat .git/HEAD
     git checkout $YT_VER
     pip install -e .
     popd
@@ -103,17 +106,17 @@ jobs:
     - stage: tests
       name: "tests with Python 2.7 and yt-dev"
       python: 2.7
-      env: YT_VER="HEAD"
+      env: YT_VER=$YT_HEAD
 
     - stage: tests
       name: "tests with Python 3.5 and yt-dev"
       python: 3.5
-      env: YT_VER="HEAD"
+      env: YT_VER=$YT_HEAD
 
     - stage: tests
       name: "tests with Python 3.6 and yt-dev"
       python: 3.6
-      env: YT_VER="HEAD"
+      env: YT_VER=$YT_HEAD
       after_success: coveralls
 
     - stage: tests


### PR DESCRIPTION
Looks like when we switched to using travis jobs, we stopped testing against yt dev tip.  This PR assures we test trident's tip with yt dev tip and yt stable so we are sensitive to changes introduced to yt dev that affect trident's operability.

Note, this will likely cause the answer tests to fail, but this is only because we weren't actually doing answer tests with the yt tip since August.  Additional work will need to `git bisect` the change in yt that caused any new failures since then.