### PR TITLE
Assures that ion_fraction field reflects on-disk fields (fixes issue #56)

### DIFF
--- a/tests/test_ion_balance.py
+++ b/tests/test_ion_balance.py
@@ -27,7 +27,8 @@ from yt.testing import \
 import tempfile
 import shutil
 from trident.testing import \
-    answer_test_data_dir
+    answer_test_data_dir, \
+    assert_array_rel_equal
 import os
 
 import numpy as np
@@ -298,3 +299,15 @@ def test_add_ion_fields_to_gizmo():
         assert isinstance(ad[field], np.ndarray)
         SlicePlot(ds, 'x', field).save(dirpath)
     shutil.rmtree(dirpath)
+
+def test_ion_fraction_field_is_from_on_disk_fields():
+    """
+    Test to add various ion fields to Enzo dataset and slice on them
+    """
+    ds = load(ISO_GALAXY)
+    add_ion_fields(ds, ['H'], ftype='gas')
+    ad = ds.all_data()
+    # Assure that a sampling of fields are added and can be sliced
+    arr1 = ad['H_p0_ion_fraction']
+    arr2 = ad['H_p0_number_density'] / ad['H_nuclei_density']
+    assert_array_rel_equal(arr1, arr2, decimals=15)

--- a/trident/ion_balance.py
+++ b/trident/ion_balance.py
@@ -476,7 +476,8 @@ def add_ion_fraction_field(atom, ion, ds, ftype="gas",
 
     # if on-disk fields exist for calculation ion_fraction, use them
     if ((ftype, "%s_p%d_number_density" % (atom, ion-1)) in ds.derived_field_list) and \
-       ((ftype, "%s_nuclei_density" % atom) in ds.derived_field_list):
+       ((ftype, "%s_nuclei_density" % atom) in ds.derived_field_list) and \
+       (force_override == False):
         ds.add_field((ftype, field), function=_internal_ion_fraction_field, units="",
                      sampling_type=sampling_type, force_override=force_override)
     # otherwise, calculate ion_fraction from ion_balance table

--- a/trident/ion_balance.py
+++ b/trident/ion_balance.py
@@ -477,7 +477,7 @@ def add_ion_fraction_field(atom, ion, ds, ftype="gas",
     # if on-disk fields exist for calculation ion_fraction, use them
     if ((ftype, "%s_p%d_number_density" % (atom, ion-1)) in ds.derived_field_list) and \
        ((ftype, "%s_nuclei_density" % atom) in ds.derived_field_list) and \
-       (force_override == False):
+       (force_override is False):
         ds.add_field((ftype, field), function=_internal_ion_fraction_field, units="",
                      sampling_type=sampling_type, force_override=force_override)
     # otherwise, calculate ion_fraction from ion_balance table
@@ -1069,6 +1069,7 @@ def _internal_ion_fraction_field(field, data):
     atom = field_array[0]
 
     return data[(ftype, "%s_number_density" % ion)] / data[(ftype, "%s_nuclei_density" % atom)]
+
 
 # Taken from Cloudy documentation.
 solar_abundance = {


### PR DESCRIPTION
The script in issue #56 now outputs:

```
[  1.09266207e-06   1.09389294e-06   1.09390709e-06 ...,   5.38337805e-01
   6.33352805e-01   9.50010426e-01] dimensionless
[  1.09266207e-06   1.09389294e-06   1.09390709e-06 ...,   5.38337805e-01
   6.33352805e-01   9.50010426e-01] dimensionless
```