### PR TITLE
Fix failing py.test

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ with open('README.md') as f:
     long_description = f.read()
 
 dev_requirements = [
-    'coveralls', 'flake8', 'pytest', 'pytest-cov', 'twine', 'wheel',
+    'coveralls', 'flake8', 'pytest>=3.6', 'pytest-cov', 'twine', 'wheel',
     'sphinx', 'scipy', 'sphinx_rtd_theme', 'gitpython']
 
 setup(

--- a/trident/testing.py
+++ b/trident/testing.py
@@ -98,7 +98,7 @@ def h5_dataset_compare(fn1, fn2, compare=None, **kwargs):
     assert list(fh1.keys()) == list(fh2.keys()), \
       "Files have different datasets!"
     for key in fh1.keys():
-        compare(fh1[key].value, fh2[key].value,
+        compare(fh1[key][()], fh2[key][()],
                 err_msg="%s field not equal!" % key, **kwargs)
 
 def assert_array_rel_equal(a1, a2, decimals=16, **kwargs):


### PR DESCRIPTION
Right now the tests are failing due to travis using an older version of pytest that does not support pytest-cov.  This bumps the version of pytest in the setup.py to a version supporting pytest-cov.  

It also avoids a bunch of test warnings we were getting by updating from a deprecated manner in which we access the h5py answer test data.  `X.value` for accessing an HDF5 datasets is deprecated and will be phased out in the future.