### PR TITLE
Fixes redshift miscalculation in ray generation for demeshened datasets

### DIFF
--- a/tests/test_light_ray.py
+++ b/tests/test_light_ray.py
@@ -16,9 +16,11 @@ import numpy as np
 from yt.convenience import \
     load
 from yt.testing import \
-    assert_array_equal
+    assert_array_equal, \
+    assert_almost_equal
 from trident import \
-    LightRay
+    LightRay, \
+    make_simple_ray
 from trident.testing import \
     answer_test_data_dir, \
     TempDirTest
@@ -28,6 +30,8 @@ COSMO_PLUS = os.path.join(answer_test_data_dir,
                           "enzo_cosmology_plus/AMRCosmology.enzo")
 COSMO_PLUS_SINGLE = os.path.join(answer_test_data_dir,
                                  "enzo_cosmology_plus/RD0009/RD0009")
+GIZMO_COSMO_SINGLE = os.path.join(answer_test_data_dir,
+                                 "gizmo_cosmology_plus/snap_N128L16_150.hdf5")
 
 def compare_light_ray_solutions(lr1, lr2):
     assert len(lr1.light_ray_solution) == len(lr2.light_ray_solution)
@@ -117,3 +121,13 @@ class LightRayTest(TempDirTest):
 
         ds = load('lightray.h5')
         compare_light_ray_solutions(lr, ds)
+
+    def test_light_ray_redshift_coverage(self):
+        """
+        Tests to assure a light ray covers the full redshift range appropriate
+        for that comoving line of sight distance.  Was not always so!
+        """
+        ds = load(GIZMO_COSMO_SINGLE)
+        ray = make_simple_ray(ds, start_position=ds.domain_left_edge, end_position=ds.domain_right_edge, lines=['H'])
+        assert_almost_equal(ray.r['redshift'][0], 0.00489571, decimal=8)
+        assert_almost_equal(ray.r['redshift'][-1], -0.00416831, decimal=8)

--- a/trident/light_ray.py
+++ b/trident/light_ray.py
@@ -510,7 +510,7 @@ class LightRay(CosmologySplice):
            fields.append(('gas', 'temperature'))
         data_fields = fields[:]
         all_fields = fields[:]
-        all_fields.extend(['dl', 'dredshift', 'redshift'])
+        all_fields.extend(['l', 'dl', 'redshift'])
         all_fields.extend(['x', 'y', 'z'])
         data_fields.extend(['x', 'y', 'z'])
         if use_peculiar_velocity:
@@ -591,6 +591,9 @@ class LightRay(CosmologySplice):
                 for key, val in field_parameters.items():
                     sub_ray.set_field_parameter(key, val)
                 asort = np.argsort(sub_ray["t"])
+                sub_data['l'].extend(sub_ray['t'][asort] *
+                                     vector_length(sub_ray.start_point,
+                                                   sub_ray.end_point))
                 sub_data['dl'].extend(sub_ray['dts'][asort] *
                                       vector_length(sub_ray.start_point,
                                                     sub_ray.end_point))
@@ -648,11 +651,11 @@ class LightRay(CosmologySplice):
                 sub_data[key] = ds.arr(sub_data[key]).in_cgs()
 
             # Get redshift for each lixel.  Assume linear relation between l
-            # and z.
-            sub_data['dredshift'] = (my_segment['redshift'] - next_redshift) * \
-                (sub_data['dl'] / vector_length(my_start, my_end).in_cgs())
+            # and z.  so z = z_start - (l * (z_range / l_range))
             sub_data['redshift'] = my_segment['redshift'] - \
-              sub_data['dredshift'].cumsum() + sub_data['dredshift']
+              (sub_data['l'] * \
+              (my_segment['redshift'] - next_redshift) / \
+              vector_length(my_start, my_end).in_cgs())
 
             # When using the peculiar velocity, create effective redshift
             # (redshift_eff) field combining cosmological redshift and

--- a/trident/ray_generator.py
+++ b/trident/ray_generator.py
@@ -44,8 +44,8 @@ def make_simple_ray(dataset_file, start_position, end_position,
     A simple ray is a straight line passing through a single dataset
     where each gas cell intersected by the line is sampled for the desired
     fields and stored.  Several additional fields are created and stored
-    including ``dl`` and ``dredshift`` to represent the path length in space and
-    redshift for each element in the ray, ``v_los`` to represent the line of
+    including ``dl`` to represent the path length in space
+    for each element in the ray, ``v_los`` to represent the line of
     sight velocity along the ray, and ``redshift``, ``redshift_dopp``, and
     ``redshift_eff`` to represent the cosmological redshift, doppler redshift
     and effective redshift (combined doppler and cosmological) for each
@@ -281,8 +281,8 @@ def make_compound_ray(parameter_filename, simulation_type,
     Like the simple ray produced by :class:`~trident.make_simple_ray`,
     each gas cell intersected by the LightRay is sampled for the desired
     fields and stored.  Several additional fields are created and stored
-    including ``dl`` and ``dredshift`` to represent the path length in space and
-    redshift for each element in the ray, ``v_los`` to represent the line of
+    including ``dl`` to represent the path length in space
+    for each element in the ray, ``v_los`` to represent the line of
     sight velocity along the ray, and ``redshift``, ``redshift_dopp``, and
     ``redshift_eff`` to represent the cosmological redshift, doppler redshift
     and effective redshift (combined doppler and cosmological) for each


### PR DESCRIPTION
Ken Nagamine identified a problem in datasets spanning a very large volume where our redshift calculation for each absorber along a LightRay is incorrect.  The root of the problem is that in pre-demeshened yt, one could rely on the fact that the path lengths associated with each element in the LightRay (i.e., the `dl` or `dt` fields) should sum to the total length of the path of the LightRay.  But the demeshening did away with this by burying information about the smoothing kernel and the proximity that the LightRay comes to the particle in the `dl` and `dt` fields, which means they no longer sum to the total path length of the LightRay.  This PR addresses this problem by calculating the position on the LightRay `l` (which in turn becomes `redshift`) without doing a cumulative sum on all of the `dl` values (or `dredshift` values) up until that point.

I have included a test on one of the cosmological gizmo datasets that explicitly assures that we cover the full redshift range expected.