### PR TITLE
Implements a better way of calculating the redshift on the light ray

### DIFF
--- a/tests/test_light_ray.py
+++ b/tests/test_light_ray.py
@@ -16,9 +16,11 @@ import numpy as np
 from yt.convenience import \
     load
 from yt.testing import \
-    assert_array_equal
+    assert_array_equal, \
+    assert_almost_equal
 from trident import \
-    LightRay
+    LightRay, \
+    make_simple_ray
 from trident.testing import \
     answer_test_data_dir, \
     TempDirTest
@@ -100,6 +102,16 @@ class LightRayTest(TempDirTest):
 
         ds = load('lightray.h5')
         compare_light_ray_solutions(lr, ds)
+
+    def test_light_ray_redshift_coverage_grid(self):
+        """
+        Tests to assure a light ray covers the full redshift range appropriate
+        for that comoving line of sight distance.  Was not always so!
+        """
+        ds = load(COSMO_PLUS_SINGLE)
+        ray = make_simple_ray(ds, start_position=ds.domain_left_edge, end_position=ds.domain_right_edge, lines=['H'])
+        assert_almost_equal(ray.r['redshift'][0], 6.99900695e-03, decimal=8)
+        assert_almost_equal(ray.r['redshift'][-1], -1.08961751e-02, decimal=8)
 
     def test_light_ray_non_cosmo_from_dataset(self):
         """

--- a/trident/light_ray.py
+++ b/trident/light_ray.py
@@ -510,7 +510,7 @@ class LightRay(CosmologySplice):
            fields.append(('gas', 'temperature'))
         data_fields = fields[:]
         all_fields = fields[:]
-        all_fields.extend(['dl', 'dredshift', 'redshift'])
+        all_fields.extend(['l', 'dl', 'redshift'])
         all_fields.extend(['x', 'y', 'z', 'dx', 'dy', 'dz'])
         data_fields.extend(['x', 'y', 'z', 'dx', 'dy', 'dz'])
         if use_peculiar_velocity:
@@ -591,6 +591,9 @@ class LightRay(CosmologySplice):
                 for key, val in field_parameters.items():
                     sub_ray.set_field_parameter(key, val)
                 asort = np.argsort(sub_ray["t"])
+                sub_data['l'].extend(sub_ray['t'][asort] *
+                                     vector_length(sub_ray.start_point,
+                                                   sub_ray.end_point))
                 sub_data['dl'].extend(sub_ray['dts'][asort] *
                                       vector_length(sub_ray.start_point,
                                                     sub_ray.end_point))
@@ -648,11 +651,11 @@ class LightRay(CosmologySplice):
                 sub_data[key] = ds.arr(sub_data[key]).in_cgs()
 
             # Get redshift for each lixel.  Assume linear relation between l
-            # and z.
-            sub_data['dredshift'] = (my_segment['redshift'] - next_redshift) * \
-                (sub_data['dl'] / vector_length(my_start, my_end).in_cgs())
+            # and z.  so z = z_start - (l * (z_range / l_range))
             sub_data['redshift'] = my_segment['redshift'] - \
-              sub_data['dredshift'].cumsum() + sub_data['dredshift']
+              (sub_data['l'] * \
+              (my_segment['redshift'] - next_redshift) / \
+              vector_length(my_start, my_end).in_cgs())
 
             # When using the peculiar velocity, create effective redshift
             # (redshift_eff) field combining cosmological redshift and

--- a/trident/ray_generator.py
+++ b/trident/ray_generator.py
@@ -47,8 +47,8 @@ def make_simple_ray(dataset_file, start_position, end_position,
     A simple ray is a straight line passing through a single dataset
     where each gas cell intersected by the line is sampled for the desired
     fields and stored.  Several additional fields are created and stored
-    including ``dl`` and ``dredshift`` to represent the path length in space and
-    redshift for each element in the ray, ``v_los`` to represent the line of
+    including ``dl`` to represent the path length in space
+    for each element in the ray, ``v_los`` to represent the line of
     sight velocity along the ray, and ``redshift``, ``redshift_dopp``, and
     ``redshift_eff`` to represent the cosmological redshift, doppler redshift
     and effective redshift (combined doppler and cosmological) for each
@@ -318,8 +318,8 @@ def make_compound_ray(parameter_filename, simulation_type,
     Like the simple ray produced by :class:`~trident.make_simple_ray`,
     each gas cell intersected by the LightRay is sampled for the desired
     fields and stored.  Several additional fields are created and stored
-    including ``dl`` and ``dredshift`` to represent the path length in space and
-    redshift for each element in the ray, ``v_los`` to represent the line of
+    including ``dl`` to represent the path length in space
+    for each element in the ray, ``v_los`` to represent the line of
     sight velocity along the ray, and ``redshift``, ``redshift_dopp``, and
     ``redshift_eff`` to represent the cosmological redshift, doppler redshift
     and effective redshift (combined doppler and cosmological) for each


### PR DESCRIPTION
This corrects the problem described in PR #69 but does it for all datasets on the master branch.  Slightly modifies test results because the redshift values get bumped over.  Will need to double check this is the case and bump the gold standard version of the answer tests.