### PR TITLE
H_p0_number_density to default, H_number_density to alias

### DIFF
--- a/trident/ion_balance.py
+++ b/trident/ion_balance.py
@@ -437,10 +437,10 @@ def add_ion_fraction_field(atom, ion, ds, ftype="gas",
 
     atom = atom.capitalize()
 
-    # if neutral ion field, alias X_p0_ion_fraction to X_ion_fraction field
+    # if neutral ion field, alias X_number_density to X_p0_number_density field
     if ion == 1:
-        field = "%s_ion_fraction" % atom
-        alias_field = "%s_p0_ion_fraction" % atom
+        field = "%s_p0_ion_fraction" % atom
+        alias_field = "%s_ion_fraction" % atom
     else:
         field = "%s_p%d_ion_fraction" % (atom, ion-1)
     if field_suffix:
@@ -571,10 +571,10 @@ def add_ion_number_density_field(atom, ion, ds, ftype="gas",
     if ionization_table is None:
         ionization_table = ion_table_filepath
     atom = atom.capitalize()
-    # if neutral ion field, alias X_p0_number_density to X_number_density field
+    # if neutral ion field, alias X_number_density to X_p0_number_density field
     if ion == 1:
-        field = "%s_number_density" % atom
-        alias_field = "%s_p0_number_density" % atom
+        field = "%s_p0_number_density" % atom
+        alias_field = "%s_number_density" % atom
     else:
         field = "%s_p%d_number_density" % (atom, ion-1)
     if field_suffix:
@@ -696,10 +696,10 @@ def add_ion_density_field(atom, ion, ds, ftype="gas",
         ionization_table = ion_table_filepath
     atom = atom.capitalize()
 
-    # if neutral ion field, alias X_p0_number_density to X_number_density field
+    # if neutral ion field, alias X_number_density to X_p0_number_density field
     if ion == 1:
-        field = "%s_density" % atom
-        alias_field = "%s_p0_density" % atom
+        field = "%s_p0_density" % atom
+        alias_field = "%s_density" % atom
     else:
         field = "%s_p%d_density" % (atom, ion-1)
     if field_suffix:
@@ -822,10 +822,10 @@ def add_ion_mass_field(atom, ion, ds, ftype="gas",
         ionization_table = ion_table_filepath
     atom = atom.capitalize()
 
-    # if neutral ion field, alias X_p0_number_density to X_number_density field
+    # if neutral ion field, alias X_number_density to X_p0_number_density field
     if ion == 1:
-        field = "%s_mass" % atom
-        alias_field = "%s_p0_mass" % atom
+        field = "%s_p0_mass" % atom
+        alias_field = "%s_mass" % atom
     else:
         field = "%s_p%s_mass" % (atom, ion-1)
     if field_suffix:

--- a/trident/ion_balance.py
+++ b/trident/ion_balance.py
@@ -438,11 +438,10 @@ def add_ion_fraction_field(atom, ion, ds, ftype="gas",
     atom = atom.capitalize()
 
     # if neutral ion field, alias X_number_density to X_p0_number_density field
+    field = "%s_p%d_ion_fraction" % (atom, ion-1)
     if ion == 1:
-        field = "%s_p0_ion_fraction" % atom
         alias_field = "%s_ion_fraction" % atom
-    else:
-        field = "%s_p%d_ion_fraction" % (atom, ion-1)
+
     if field_suffix:
         field += "_%s" % ionization_table.split(os.sep)[-1].split(".h5")[0]
         if ion == 1:
@@ -572,11 +571,10 @@ def add_ion_number_density_field(atom, ion, ds, ftype="gas",
         ionization_table = ion_table_filepath
     atom = atom.capitalize()
     # if neutral ion field, alias X_number_density to X_p0_number_density field
+    field = "%s_p%d_number_density" % (atom, ion-1)
     if ion == 1:
-        field = "%s_p0_number_density" % atom
         alias_field = "%s_number_density" % atom
-    else:
-        field = "%s_p%d_number_density" % (atom, ion-1)
+
     if field_suffix:
         field += "_%s" % ionization_table.split(os.sep)[-1].split(".h5")[0]
         if ion == 1:
@@ -697,11 +695,10 @@ def add_ion_density_field(atom, ion, ds, ftype="gas",
     atom = atom.capitalize()
 
     # if neutral ion field, alias X_number_density to X_p0_number_density field
+    field = "%s_p%d_density" % (atom, ion-1)
     if ion == 1:
-        field = "%s_p0_density" % atom
         alias_field = "%s_density" % atom
-    else:
-        field = "%s_p%d_density" % (atom, ion-1)
+
     if field_suffix:
         field += "_%s" % ionization_table.split(os.sep)[-1].split(".h5")[0]
         if ion == 1:
@@ -823,11 +820,10 @@ def add_ion_mass_field(atom, ion, ds, ftype="gas",
     atom = atom.capitalize()
 
     # if neutral ion field, alias X_number_density to X_p0_number_density field
+    field = "%s_p%s_mass" % (atom, ion-1)
     if ion == 1:
-        field = "%s_p0_mass" % atom
         alias_field = "%s_mass" % atom
-    else:
-        field = "%s_p%s_mass" % (atom, ion-1)
+
     if field_suffix:
         field += "_%s" % ionization_table.split(os.sep)[-1].split(".h5")[0]
         if ion == 1:

--- a/trident/ray_generator.py
+++ b/trident/ray_generator.py
@@ -79,7 +79,7 @@ def make_simple_ray(dataset_file, start_position, end_position,
     **Parameters**
 
     :dataset_file: string or yt Dataset object
-    
+
         Either a yt dataset or the filename of a dataset on disk.  If you are
         passing it a filename, consider usage of the ``load_kwargs`` and
         ``setup_function`` kwargs.
@@ -138,7 +138,7 @@ def make_simple_ray(dataset_file, start_position, end_position,
         Default: None
 
     :data_filename: string, optional
-    
+
         Output filename for ray data stored as an HDF5 file.  Note that
         at present, you *must* save a ray to disk in order for it to be
         returned by this function.  If set to None, defaults to 'ray.h5'.
@@ -314,7 +314,7 @@ def make_compound_ray(parameter_filename, simulation_type,
     in the dataset volume, the compound ray requires the near_redshift and
     far_redshift to determine which datasets to use to get full coverage
     in redshift space as the ray propagates from near_redshift to far_redshift.
-    
+
     Like the simple ray produced by :class:`~trident.make_simple_ray`,
     each gas cell intersected by the LightRay is sampled for the desired
     fields and stored.  Several additional fields are created and stored
@@ -334,7 +334,7 @@ def make_compound_ray(parameter_filename, simulation_type,
     to set the :ftype: keyword appropriately, or you may end up calculating
     ion fields by interpolating on data already smoothed to the grid.  This is
     generally not desired.
- 
+
     **Parameters**
 
     :parameter_filename: string
@@ -639,8 +639,8 @@ def _determine_fields_from_ions(ds, ion_list, fields, ftype, sampling_type):
         nuclei_field = "%s_nuclei_mass_density" % atom
         metallicity_field = "%s_metallicity" % atom
         if ion_state == 1:
-            field = "%s_number_density" % atom
-            alias_field = "%s_p0_number_density" % atom
+            field = "%s_p0_number_density" % atom
+            alias_field = "%s_number_density" % atom
         else:
             field = "%s_p%d_number_density" % (atom, ion_state-1)
             alias_field = "%s_p%d_number_density" % (atom, ion_state-1)

--- a/trident/ray_generator.py
+++ b/trident/ray_generator.py
@@ -638,39 +638,39 @@ def _determine_fields_from_ions(ds, ion_list, fields, ftype, sampling_type):
         ion_state = ion[1]
         nuclei_field = "%s_nuclei_mass_density" % atom
         metallicity_field = "%s_metallicity" % atom
+        field = "%s_p%d_number_density" % (atom, ion_state-1)
+
+        # if neutral ion field, alias X_number_density to X_p0_number_density field
         if ion_state == 1:
-            field = "%s_p0_number_density" % atom
             alias_field = "%s_number_density" % atom
-        else:
-            field = "%s_p%d_number_density" % (atom, ion_state-1)
-            alias_field = "%s_p%d_number_density" % (atom, ion_state-1)
 
         # This is ugly, but I couldn't find a way around it to hit
         # all 6 cases of when fields were present or not and particle
         # type or not.
         if (ftype, field) not in ds.derived_field_list:
-            if (ftype, alias_field) not in ds.derived_field_list:
-                if sampling_type == 'particle':
-                    fields_to_add_to_ds.append((atom, ion_state))
-                    fields.append(("gas", alias_field))
-                else:
-                    # If this is a  grid-based field where the ion field
-                    # doesn't yet exist, just append the density and
-                    # appropriate metal field for ion field calculation
-                    # on the ray itself instead of adding it to the full ds
-                    fields.append(('gas', 'density'))
-                    if ('gas', metallicity_field) in ds.derived_field_list:
-                        fields.append(('gas', metallicity_field))
-                    elif ('gas', nuclei_field) in ds.derived_field_list:
-                        fields.append(('gas', nuclei_field))
-                    elif atom != 'H':
-                        fields.append(('gas', 'metallicity'))
-                    else:
-                        # Don't need metallicity field if we're just looking
-                        # at hydrogen
-                        pass
-            else:
+            #check if alias is present for neutral case
+            if ion_state == 1 and (ftype, alias_field) in ds.derived_field_list:
                 fields.append(("gas", alias_field))
+
+            elif sampling_type == 'particle':
+                fields_to_add_to_ds.append((atom, ion_state))
+                fields.append(("gas", alias_field))
+            else:
+                # If this is a  grid-based field where the ion field
+                # doesn't yet exist, just append the density and
+                # appropriate metal field for ion field calculation
+                # on the ray itself instead of adding it to the full ds
+                fields.append(('gas', 'density'))
+                if ('gas', metallicity_field) in ds.derived_field_list:
+                    fields.append(('gas', metallicity_field))
+                elif ('gas', nuclei_field) in ds.derived_field_list:
+                    fields.append(('gas', nuclei_field))
+                elif atom != 'H':
+                    fields.append(('gas', 'metallicity'))
+                else:
+                    # Don't need metallicity field if we're just looking
+                    # at hydrogen
+                    pass
         else:
             fields.append(("gas", field))
 

--- a/trident/ray_generator.py
+++ b/trident/ray_generator.py
@@ -640,21 +640,13 @@ def _determine_fields_from_ions(ds, ion_list, fields, ftype, sampling_type):
         metallicity_field = "%s_metallicity" % atom
         field = "%s_p%d_number_density" % (atom, ion_state-1)
 
-        # if neutral ion field, alias X_number_density to X_p0_number_density field
-        if ion_state == 1:
-            alias_field = "%s_number_density" % atom
-
         # This is ugly, but I couldn't find a way around it to hit
         # all 6 cases of when fields were present or not and particle
         # type or not.
         if (ftype, field) not in ds.derived_field_list:
-            #check if alias is present for neutral case
-            if ion_state == 1 and (ftype, alias_field) in ds.derived_field_list:
-                fields.append(("gas", alias_field))
-
-            elif sampling_type == 'particle':
+            if sampling_type == 'particle':
                 fields_to_add_to_ds.append((atom, ion_state))
-                fields.append(("gas", alias_field))
+                fields.append(("gas", field))
             else:
                 # If this is a  grid-based field where the ion field
                 # doesn't yet exist, just append the density and

--- a/trident/ray_generator.py
+++ b/trident/ray_generator.py
@@ -640,31 +640,41 @@ def _determine_fields_from_ions(ds, ion_list, fields, ftype, sampling_type):
         metallicity_field = "%s_metallicity" % atom
         field = "%s_p%d_number_density" % (atom, ion_state-1)
 
+        if ion_state == 1:
+            alias_field = "%s_number_density" % atom
+        else:
+            alias_field = field
+
         # This is ugly, but I couldn't find a way around it to hit
         # all 6 cases of when fields were present or not and particle
         # type or not.
         if (ftype, field) not in ds.derived_field_list:
-            if sampling_type == 'particle':
-                fields_to_add_to_ds.append((atom, ion_state))
-                fields.append(("gas", field))
-            else:
-                # If this is a  grid-based field where the ion field
-                # doesn't yet exist, just append the density and
-                # appropriate metal field for ion field calculation
-                # on the ray itself instead of adding it to the full ds
-                fields.append(('gas', 'density'))
-                if ('gas', metallicity_field) in ds.derived_field_list:
-                    fields.append(('gas', metallicity_field))
-                elif ('gas', nuclei_field) in ds.derived_field_list:
-                    fields.append(('gas', nuclei_field))
-                elif atom != 'H':
-                    fields.append(('gas', 'metallicity'))
+            if (ftype, alias_field) not in ds.derived_field_list:
+                if sampling_type == 'particle':
+                    fields_to_add_to_ds.append((atom, ion_state))
+                    fields.append(("gas", field))
                 else:
-                    # Don't need metallicity field if we're just looking
-                    # at hydrogen
-                    pass
+                    # If this is a  grid-based field where the ion field
+                    # doesn't yet exist, just append the density and
+                    # appropriate metal field for ion field calculation
+                    # on the ray itself instead of adding it to the full ds
+                    fields.append(('gas', 'density'))
+                    if ('gas', metallicity_field) in ds.derived_field_list:
+                        fields.append(('gas', metallicity_field))
+                    elif ('gas', nuclei_field) in ds.derived_field_list:
+                        fields.append(('gas', nuclei_field))
+                    elif atom != 'H':
+                        fields.append(('gas', 'metallicity'))
+                    else:
+                        # Don't need metallicity field if we're just looking
+                        # at hydrogen
+                        pass
+
+            else:
+                fields.append(("gas", alias_field))
         else:
             fields.append(("gas", field))
+
 
     return fields, fields_to_add_to_ds
 

--- a/trident/utilities.py
+++ b/trident/utilities.py
@@ -434,12 +434,6 @@ def make_onezone_ray(density=1e-26, temperature=1000, metallicity=0.3,
     # Add additional number_density fields to dataset
     if column_densities:
         for k,v in six.iteritems(column_densities):
-            # Assure we add X_number_density for neutral ions
-            # instead of X_p0_number_density
-            key_string_list = k.split('_')
-            if key_string_list[1] == 'p0':
-                k = '_'.join([key_string_list[0], key_string_list[2],
-                              key_string_list[3]])
             v = YTArray([v], 'cm**-2')
             data[k] = v/length
             field_types[k] = 'grid'


### PR DESCRIPTION
Changed the naming convention to default to H_p0_number_density instead of H_number_density.

Made edits to ray_generator.py and ion_balance.py so that the field name is set to "H_p0_number_density" like all other ionization cases. Additionally, an alias field is set to "H_number_density" in case that naming convention is used. 

ion_balance.py is edited in a similar way.

Did not make any edits to spectrum_generator.py, but on line 368 there is some code that deals with using the correct naming convention. I don't believe this needs any changing but it does call alias_field = "H_p0_number_density" which could be confusing to someone reading the code.