### PR TITLE
Fixing h5py syntax deprecation

### DIFF
--- a/trident/ion_balance.py
+++ b/trident/ion_balance.py
@@ -81,7 +81,7 @@ class IonBalanceTable(object):
         """
 
         input = h5py.File(self.filename, 'r')
-        self.ion_fraction = input[atom].value
+        self.ion_fraction = input[atom][()]
         self.ion_fraction[self.ion_fraction < np.log10(fraction_zero_point)] = zero_out_value
         for par in range(1, len(self.ion_fraction.shape) - 1):
             name = "Parameter%d" % par

--- a/trident/spectrum_generator.py
+++ b/trident/spectrum_generator.py
@@ -1073,9 +1073,9 @@ def load_spectrum(filename, format='auto', instrument=None, lsf_kernel=None,
             format = 'ascii'
     if format == 'hdf5':
         f = _h5py.File(filename, 'r')
-        lambda_field = f['wavelength'].value
-        flux_field = f['flux'].value
-        tau_field = f['tau'].value
+        lambda_field = f['wavelength'][()]
+        flux_field = f['flux'][()]
+        tau_field = f['tau'][()]
     elif format == 'fits':
         pyfits = _astropy.pyfits
         hdulist = pyfits.open(filename)


### PR DESCRIPTION
In new versions of h5py module, h5py will complain about accessing datasets using the syntax:

`data.value`

and now wants you to use:

`data[()]`

This PR addresses that change to avoid deprecation warnings and eventual breaks in future versions of h5py.