### PR TITLE
Adding support for bulk velocity subtraction

### DIFF
--- a/trident/light_ray.py
+++ b/trident/light_ray.py
@@ -311,6 +311,7 @@ class LightRay(CosmologySplice):
                        fields=None, setup_function=None,
                        solution_filename=None, data_filename=None,
                        get_los_velocity=None, use_peculiar_velocity=True,
+                       bulk_velocity=None,
                        redshift=None, field_parameters=None, njobs=-1):
         """
         Actually generate the LightRay by traversing the desired dataset.
@@ -407,6 +408,13 @@ class LightRay(CosmologySplice):
             calculating the effective redshift combining the cosmological
             redshift and the doppler redshift.
             Default: True.
+
+        :bulk_velocity: YTArray object
+        
+            The bulk velocity of the simulation. This will be subtracted from 
+            the velocity fields when calculating the doppler redshift due to the  
+            peculiar velocity.   
+            Default: None 
 
         :redshift: optional, float
 
@@ -600,6 +608,16 @@ class LightRay(CosmologySplice):
 
                 for field in data_fields:
                     sub_data[field].extend(sub_ray[field][asort])
+
+                    
+                if bulk_velocity is not None:
+                    # if there's a bulk velocity, subtract it from the ray velocity
+                    # before calculating doppler shift
+                    sub_ray['velocity_x'] -= bulk_velocity[0]
+                    sub_ray['velocity_y'] -= bulk_velocity[1]
+                    sub_ray['velocity_z'] -= bulk_velocity[2]
+                    sub_ray['velocity_magnitude'] = np.sqrt(sub_ray['velocity_x']**2 +\
+                                 sub_ray['velocity_y']**2 + sub_ray['velocity_z']**2)
 
                 if use_peculiar_velocity:
                     line_of_sight = sub_segment[0] - sub_segment[1]

--- a/trident/light_ray.py
+++ b/trident/light_ray.py
@@ -311,7 +311,6 @@ class LightRay(CosmologySplice):
                        fields=None, setup_function=None,
                        solution_filename=None, data_filename=None,
                        get_los_velocity=None, use_peculiar_velocity=True,
-                       bulk_velocity=None,
                        redshift=None, field_parameters=None, njobs=-1):
         """
         Actually generate the LightRay by traversing the desired dataset.
@@ -408,13 +407,6 @@ class LightRay(CosmologySplice):
             calculating the effective redshift combining the cosmological
             redshift and the doppler redshift.
             Default: True.
-
-        :bulk_velocity: YTArray object
-        
-            The bulk velocity of the simulation. This will be subtracted from 
-            the velocity fields when calculating the doppler redshift due to the  
-            peculiar velocity.   
-            Default: None 
 
         :redshift: optional, float
 
@@ -610,13 +602,14 @@ class LightRay(CosmologySplice):
                     sub_data[field].extend(sub_ray[field][asort])
 
                     
-                if bulk_velocity is not None:
-                    # if there's a bulk velocity, subtract it from the ray velocity
-                    # before calculating doppler shift
-                    sub_ray['velocity_x'] -= bulk_velocity[0]
-                    sub_ray['velocity_y'] -= bulk_velocity[1]
-                    sub_ray['velocity_z'] -= bulk_velocity[2]
-                    sub_ray['velocity_magnitude'] = np.sqrt(sub_ray['velocity_x']**2 +\
+                # Subtract the bulk velocity from the ray's total velocity
+                bulk_velocity = sub_ray.get_field_parameter('bulk_velocity')
+                print('***** trident bulk velocity ****')
+                print(bulk_velocity)
+                sub_ray['velocity_x'] -= bulk_velocity[0]
+                sub_ray['velocity_y'] -= bulk_velocity[1]
+                sub_ray['velocity_z'] -= bulk_velocity[2]
+                sub_ray['velocity_magnitude'] = np.sqrt(sub_ray['velocity_x']**2 +\
                                  sub_ray['velocity_y']**2 + sub_ray['velocity_z']**2)
 
                 if use_peculiar_velocity:

--- a/trident/ray_generator.py
+++ b/trident/ray_generator.py
@@ -33,7 +33,7 @@ from trident.ion_balance import \
 def make_simple_ray(dataset_file, start_position, end_position,
                     lines=None, ftype="gas", fields=None,
                     solution_filename=None, data_filename=None,
-                    trajectory=None, redshift=None, bulk_velocity=None,
+                    trajectory=None, redshift=None, field_parameters=None,
                     setup_function=None, load_kwargs=None,
                     line_database=None, ionization_table=None):
     """
@@ -104,13 +104,6 @@ def make_simple_ray(dataset_file, start_position, end_position,
         See :lines: keyword for additional functionality that will add fields
         necessary for creating absorption line spectra for certain line
         features.
-        Default: None
-
-    :bulk_velocity: YTArray object
-
-        The bulk velocity of the simulation. This will be subtracted from
-        the velocity fields when calculating the doppler redshift due to the
-        peculiar velocity. 
         Default: None
 
     :solution_filename: string, optional
@@ -233,7 +226,7 @@ def make_simple_ray(dataset_file, start_position, end_position,
                              setup_function=setup_function,
                              solution_filename=solution_filename,
                              data_filename=data_filename,
-                             bulk_velocity=bulk_velocity,
+                             field_parameters=field_parameters,
                              redshift=redshift)
 
 def make_compound_ray(parameter_filename, simulation_type,

--- a/trident/ray_generator.py
+++ b/trident/ray_generator.py
@@ -233,7 +233,6 @@ def make_simple_ray(dataset_file, start_position, end_position,
                              setup_function=setup_function,
                              solution_filename=solution_filename,
                              data_filename=data_filename,
-                             field_parameters=field_parameters,
                              bulk_velocity=bulk_velocity,
                              redshift=redshift)
 

--- a/trident/ray_generator.py
+++ b/trident/ray_generator.py
@@ -33,7 +33,7 @@ from trident.ion_balance import \
 def make_simple_ray(dataset_file, start_position, end_position,
                     lines=None, ftype="gas", fields=None,
                     solution_filename=None, data_filename=None,
-                    trajectory=None, redshift=None,
+                    trajectory=None, redshift=None, bulk_velocity=None,
                     setup_function=None, load_kwargs=None,
                     line_database=None, ionization_table=None):
     """
@@ -104,6 +104,13 @@ def make_simple_ray(dataset_file, start_position, end_position,
         See :lines: keyword for additional functionality that will add fields
         necessary for creating absorption line spectra for certain line
         features.
+        Default: None
+
+    :bulk_velocity: YTArray object
+
+        The bulk velocity of the simulation. This will be subtracted from
+        the velocity fields when calculating the doppler redshift due to the
+        peculiar velocity. 
         Default: None
 
     :solution_filename: string, optional
@@ -226,6 +233,8 @@ def make_simple_ray(dataset_file, start_position, end_position,
                              setup_function=setup_function,
                              solution_filename=solution_filename,
                              data_filename=data_filename,
+                             field_parameters=field_parameters,
+                             bulk_velocity=bulk_velocity,
                              redshift=redshift)
 
 def make_compound_ray(parameter_filename, simulation_type,


### PR DESCRIPTION
Small change that subtracts out the user-provided bulk velocity of the galaxy/gas before calculating the total line-of-sight velocity. 