### PR TITLE
[bugfix] off by one error in subgrid index calculation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ env:
     TRIDENT_CONFIG=$TRIDENT_ION_DATA/config.tri
     YT_GOLD=953248239966
     YT_HEAD=master
-    TRIDENT_GOLD=test-standard-v3
+    TRIDENT_GOLD=test-standard-v4
 
 before_install:
   - |

--- a/trident/absorption_spectrum/absorption_spectrum.py
+++ b/trident/absorption_spectrum/absorption_spectrum.py
@@ -657,7 +657,7 @@ class AbsorptionSpectrum(object):
                 # window in the original spectrum's tau array
                 else:
                     intersect_left_index = max(left_index, 0)
-                    intersect_right_index = min(right_index, self.n_lambda-1)
+                    intersect_right_index = min(right_index, self.n_lambda)
                     EW_tau_deposit = EW_tau[(intersect_left_index - left_index): \
                                             (intersect_right_index - left_index)]
                     self.tau_field[intersect_left_index:intersect_right_index] \


### PR DESCRIPTION
The `intersect_right_index` variable should max out at `n_lambda` and not `n_lambda-1` since it's used as an upper bound for slice indexing. I discovered this in the process of debugging the auto-wavelength functionality (coming soon). I'm issuing this as a separate PR to see how it affects the tests.