### PR TITLE
Add ability to set wavelength limits to 'auto'

### DIFF
--- a/doc/source/advanced_spectra.rst
+++ b/doc/source/advanced_spectra.rst
@@ -142,3 +142,25 @@ Giving us:
 To understand how to further customize your spectra, look at the documentation 
 for the :class:`~trident.SpectrumGenerator` and :class:`~trident.LineDatabase`
 classes and other :ref:`API <api-reference>` documentation.
+
+Setting Wavelength Bounds Automatically
+---------------------------------------
+
+If you are interested in creating a spectrum that contains all possible
+absorption features for a given set of lines, the
+:class:`~trident.SpectrumGenerator` can be configured to automatically
+enlarge the wavelength window until all absorption is captured. This is
+done by setting the ``lambda_min`` and ``lambda_max`` keywords to 'auto'
+and specifying a bin size with the ``dlambda`` keyword::
+
+    sg = trident.SpectrumGenerator(lambda_min='auto', lambda_max='auto',
+                                   dlambda=0.01)
+    sg.make_spectrum("ray.h5", lines=['H I 1216'])
+    sg.plot_spectrum('spec_auto.png')
+
+.. image:: https://raw.githubusercontent.com/trident-project/trident-docs-images/master/spec_auto.png
+
+Note, the above example is for a different ray than is used in the
+previous examples. The resulting spectrum will minimally contain all
+absorption present in the ray. This should be used with care when depositing
+multiple lines as this can lead to an extremely large spectrum.

--- a/tests/test_auto_lambda.py
+++ b/tests/test_auto_lambda.py
@@ -1,0 +1,133 @@
+"""
+tests for auto-lambda feature
+"""
+
+#-----------------------------------------------------------------------------
+# Copyright (c) Trident Development Team. All rights reserved.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+#-----------------------------------------------------------------------------
+
+import os
+from yt.convenience import load
+from yt.testing import \
+    assert_allclose
+
+from trident import \
+    make_simple_ray, \
+    SpectrumGenerator
+from trident.testing import \
+    answer_test_data_dir, \
+    TempDirTest
+
+COSMO_PLUS_SINGLE = os.path.join(answer_test_data_dir,
+                                 "enzo_cosmology_plus/RD0009/RD0009")
+
+def compare_spectra(sg1, sg2, comp_key):
+    assert_allclose(
+        sg1.tau_field, sg2.tau_field, rtol=1e-6,
+        err_msg='tau arrays for auto and %s disagree!' % comp_key)
+    assert_allclose(
+        sg1.lambda_field, sg2.lambda_field, rtol=1e-10,
+        err_msg='lambda arrays for auto and %s disagree!' % comp_key)
+
+    for my_line in sg1.line_observables_dict:
+        for key in sg1.line_observables_dict[my_line]:
+            assert_allclose(
+                sg1.line_observables_dict[my_line][key],
+                sg2.line_observables_dict[my_line][key], rtol=1e-7,
+                err_msg='%s field for auto and %s disagree!' % (key, comp_key))
+
+class AutoLambdaTest(TempDirTest):
+
+    def setUp(self):
+        super(AutoLambdaTest, self).setUp()
+        ds = load(COSMO_PLUS_SINGLE)
+        line_list = ['H I 1216', 'H I 1026']
+
+        make_simple_ray(ds, start_position=ds.domain_left_edge,
+                        end_position=ds.domain_right_edge,
+                        data_filename='ray.h5',
+                        lines=line_list, ftype='gas')
+        self.line_list = line_list
+
+    def test_dlambda(self):
+        """
+        Compare auto wavelength against setting same min, max, and dlambda
+        """
+
+        sg_auto = SpectrumGenerator(
+            lambda_min='auto', lambda_max='auto',
+            dlambda=0.01)
+        sg_auto.make_spectrum("ray.h5", lines=self.line_list,
+                              store_observables=True)
+
+        sg_comp = SpectrumGenerator(
+            lambda_min=sg_auto.lambda_field[0].d,
+            lambda_max=sg_auto.lambda_field[-1].d,
+            dlambda=sg_auto.bin_width.d)
+        sg_comp.make_spectrum("ray.h5", lines=self.line_list,
+                              store_observables=True)
+        compare_spectra(sg_auto, sg_comp, 'manually setting dlambda')
+
+    def test_n_lambda(self):
+        """
+        Compare auto wavelength against setting same min, max, and n_lambda
+        """
+
+        sg_auto = SpectrumGenerator(
+            lambda_min='auto', lambda_max='auto',
+            dlambda=0.01)
+        sg_auto.make_spectrum("ray.h5", lines=self.line_list,
+                              store_observables=True)
+
+        sg_comp = SpectrumGenerator(
+            lambda_min=sg_auto.lambda_field[0].d,
+            lambda_max=sg_auto.lambda_field[-1].d,
+            n_lambda=sg_auto.lambda_field.size)
+        sg_comp.make_spectrum("ray.h5", lines=self.line_list,
+                              store_observables=True)
+        compare_spectra(sg_auto, sg_comp, 'manually setting n_lambda')
+
+    def test_dlambda_extra_wide(self):
+        """
+        Compare auto wavelength against setting same dlambda with
+        min and max set extra wide.
+        """
+
+        sg_auto = SpectrumGenerator(
+            lambda_min='auto', lambda_max='auto',
+            dlambda=0.01)
+        sg_auto.make_spectrum("ray.h5", lines=self.line_list,
+                              store_observables=True)
+
+        sg_comp = SpectrumGenerator(
+            lambda_min=sg_auto.lambda_field[0].d,
+            lambda_max=sg_auto.lambda_field[-1].d,
+            n_lambda=sg_auto.lambda_field.size)
+        sg_comp.make_spectrum("ray.h5", lines=self.line_list,
+                              store_observables=True)
+
+        assert_allclose(
+            sg_auto.tau_field.sum(),
+            sg_comp.tau_field.sum(), rtol=1e-7,
+            err_msg='Total tau disagrees with extra wide spectrum.')
+
+    def test_empty_spectrum(self):
+        """
+        Test we can make an empty spectrum without crashing.
+        """
+
+        sg = SpectrumGenerator(lambda_max=1100,
+                               lambda_min='auto',
+                               dlambda=0.01)
+        sg.make_spectrum("ray.h5", lines=['H I 1216'],
+                         output_file='blank.h5',
+                         output_absorbers_file='blank.txt',
+                         store_observables=True, ly_continuum=True)
+        sg.plot_spectrum('spec_blank.png')
+        assert sg.lambda_field is None
+        assert sg.tau_field is None
+        assert sg.flux_field is None

--- a/tests/test_auto_lambda.py
+++ b/tests/test_auto_lambda.py
@@ -131,3 +131,49 @@ class AutoLambdaTest(TempDirTest):
         assert sg.lambda_field is None
         assert sg.tau_field is None
         assert sg.flux_field is None
+
+    def test_setting_lambda_min(self):
+        """
+        Test setting an arbitrary lambda_min with auto-lambda.
+        """
+
+        sg_auto = SpectrumGenerator(
+            lambda_min='auto', lambda_max='auto',
+            dlambda=0.01)
+        sg_auto.make_spectrum("ray.h5", lines=self.line_list,
+                              ly_continuum=False)
+
+        sg_comp = SpectrumGenerator(
+            lambda_min=1100, lambda_max='auto',
+            dlambda=0.01)
+        sg_comp.make_spectrum("ray.h5", lines=self.line_list,
+                              ly_continuum=False)
+
+        comp_lambda = sg_auto.lambda_field >= sg_comp.lambda_field[0]
+
+        assert_allclose(
+            sg_auto.tau_field[comp_lambda].sum(),
+            sg_comp.tau_field.sum())
+
+    def test_setting_lambda_max(self):
+        """
+        Test setting an arbitrary lambda_max with auto-lambda.
+        """
+
+        sg_auto = SpectrumGenerator(
+            lambda_min='auto', lambda_max='auto',
+            dlambda=0.01)
+        sg_auto.make_spectrum("ray.h5", lines=self.line_list,
+                              ly_continuum=False)
+
+        sg_comp = SpectrumGenerator(
+            lambda_min='auto', lambda_max=1100,
+            dlambda=0.01)
+        sg_comp.make_spectrum("ray.h5", lines=self.line_list,
+                              ly_continuum=False)
+
+        comp_lambda = sg_auto.lambda_field <= sg_comp.lambda_field[-1]
+
+        assert_allclose(
+            sg_auto.tau_field[comp_lambda].sum(),
+            sg_comp.tau_field.sum())

--- a/tests/test_bad_inputs.py
+++ b/tests/test_bad_inputs.py
@@ -1,0 +1,34 @@
+"""
+tests for giving bad inputs
+"""
+
+#-----------------------------------------------------------------------------
+# Copyright (c) Trident Development Team. All rights reserved.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+#-----------------------------------------------------------------------------
+
+from numpy.testing import \
+    assert_raises
+
+from trident.absorption_spectrum.absorption_spectrum import \
+    AbsorptionSpectrum
+
+def test_no_n_lambda_or_dlambda():
+    with assert_raises(RuntimeError):
+        AbsorptionSpectrum(
+            lambda_min=1100, lambda_max=1200)
+
+def test_n_lambda_with_auto():
+    with assert_raises(RuntimeError):
+        AbsorptionSpectrum(
+            lambda_min='auto', lambda_max='auto',
+            n_lambda=1000)
+
+def test_min_greater_than_max():
+    with assert_raises(RuntimeError):
+        AbsorptionSpectrum(
+            lambda_min=1200, lambda_max=1100,
+            n_lambda=1000)

--- a/trident/absorption_spectrum/absorption_spectrum.py
+++ b/trident/absorption_spectrum/absorption_spectrum.py
@@ -65,7 +65,7 @@ class AbsorptionSpectrum(object):
     """
 
     def __init__(self, lambda_min, lambda_max, n_lambda=None, dlambda=None):
-        if (n_lambda is None) ^ (dlambda is None):
+        if not ((n_lambda is None) ^ (dlambda is None)):
             raise RuntimeError(
                 'Either n_lambda or dlambda must be given, but not both.')
 

--- a/trident/absorption_spectrum/absorption_spectrum.py
+++ b/trident/absorption_spectrum/absorption_spectrum.py
@@ -19,25 +19,25 @@ from __future__ import absolute_import
 from yt.utilities.on_demand_imports import _h5py as h5py
 import numpy as np
 
-from trident.absorption_spectrum.absorption_line import \
-    tau_profile
-
 from yt.data_objects.data_containers import \
     YTDataContainer
 from yt.data_objects.static_output import \
     Dataset
-from yt.extern.six import string_types
 from yt.convenience import load
+from yt.extern.six import string_types
 from yt.funcs import get_pbar, mylog
 from yt.units.yt_array import YTArray, YTQuantity
-from yt.utilities.physical_constants import \
-    boltzmann_constant_cgs, \
-    speed_of_light_cgs
 from yt.utilities.on_demand_imports import _astropy
 from yt.utilities.parallel_tools.parallel_analysis_interface import \
     _get_comm, \
     parallel_objects, \
     parallel_root_only
+from yt.utilities.physical_constants import \
+    boltzmann_constant_cgs, \
+    speed_of_light_cgs
+
+from trident.absorption_spectrum.absorption_line import \
+    tau_profile
 
 pyfits = _astropy.pyfits
 

--- a/trident/absorption_spectrum/absorption_spectrum.py
+++ b/trident/absorption_spectrum/absorption_spectrum.py
@@ -96,7 +96,8 @@ class AbsorptionSpectrum(object):
             lambda_max = YTQuantity(lambda_max, 'angstrom')
         self.lambda_max = lambda_max
 
-        self._auto_lambda = 'auto' in [self.lambda_min, self.lambda_max]
+        self._auto_lambda = 'auto' in [str(self.lambda_min),
+                                       str(self.lambda_max)]
         if self._auto_lambda and \
           (n_lambda is not None and n_lambda != 'auto'):
             raise RuntimeError(

--- a/trident/absorption_spectrum/absorption_spectrum.py
+++ b/trident/absorption_spectrum/absorption_spectrum.py
@@ -64,20 +64,31 @@ class AbsorptionSpectrum(object):
        number of wavelength bins.
     """
 
-    def __init__(self, lambda_min, lambda_max, n_lambda):
-        self.n_lambda = int(n_lambda)
-        # lambda, flux, and tau are wavelength, flux, and optical depth
+    def __init__(self, lambda_min, lambda_max, n_lambda=None, dlambda=None):
+        if (n_lambda is None) ^ (dlambda is None):
+            raise RuntimeError(
+                'Either n_lambda or dlambda must be given, but not both.')
+
         self.lambda_min = lambda_min
         self.lambda_max = lambda_max
-        self.lambda_field = YTArray(np.linspace(lambda_min, lambda_max,
-                                    n_lambda), "angstrom")
+        self.n_lambda = n_lambda
+        if dlambda is not None:
+            self.bin_width = YTQuantity(dlambda, 'angstrom')
+            self.lambda_field = None
+        else:
+            self.n_lambda = int(n_lambda)
+            self.bin_width = YTQuantity(
+                float(lambda_max - lambda_min) / (n_lambda - 1), "angstrom")
+
+            # lambda, flux, and tau are wavelength, flux, and optical depth
+            self.lambda_field = YTArray(np.linspace(lambda_min, lambda_max,
+                                        n_lambda), "angstrom")
+
         self.tau_field = None
         self.flux_field = None
         self.absorbers_list = None
         # a dictionary that will store spectral quantities for each index in the light ray
         self.line_observables_dict = None
-        self.bin_width = YTQuantity((lambda_max - lambda_min) /
-                                    float(n_lambda - 1), "angstrom")
         self.line_list = []
         self.continuum_list = []
         self.snr = 100  # default signal to noise ratio for error estimation

--- a/trident/absorption_spectrum/absorption_spectrum.py
+++ b/trident/absorption_spectrum/absorption_spectrum.py
@@ -479,6 +479,7 @@ class AbsorptionSpectrum(object):
             mylog.warning(
                 'Cannot add continuum with empty spectrum and lambda_min/max ' +
                 'set to auto.')
+            return
 
         # Change the redshifts of continuum sources to account for the
         # redshift at which the observer sits
@@ -912,9 +913,9 @@ class AbsorptionSpectrum(object):
         new_lambda_max = my_lambda[0] + \
           dlambda * max(my_lambda.size, right_index)
 
-        if self.lambda_min != 'auto':
+        if str(self.lambda_min) != 'auto':
             new_lambda_min = max(new_lambda_min, self.lambda_min)
-        if self.lambda_max != 'auto':
+        if str(self.lambda_max) != 'auto':
             new_lambda_max = min(new_lambda_max, self.lambda_max)
         if new_lambda_min >= new_lambda_max:
             return

--- a/trident/absorption_spectrum/absorption_spectrum.py
+++ b/trident/absorption_spectrum/absorption_spectrum.py
@@ -108,7 +108,7 @@ class AbsorptionSpectrum(object):
             if not self._auto_lambda:
                 n_lambda = \
                   self._get_field_size(self.lambda_min, self.lambda_max,
-                                       self.bin_width, do_round=True)
+                                       self.bin_width)
 
         if self._auto_lambda:
             self.lambda_field = None
@@ -132,7 +132,7 @@ class AbsorptionSpectrum(object):
         self.continuum_list = []
         self.snr = 100  # default signal to noise ratio for error estimation
 
-    def _get_field_size(self, lambda_min, lambda_max, dlambda, do_round=False):
+    def _get_field_size(self, lambda_min, lambda_max, dlambda):
         """
         Calculate number of bins.
         """
@@ -153,9 +153,8 @@ class AbsorptionSpectrum(object):
             my_dlambda = dlambda
 
         n_lambda = (my_max - my_min) / my_dlambda + 1
-        if do_round:
-            n_lambda = np.round(n_lambda)
-        return int(n_lambda)
+        n_lambda = int(np.round(n_lambda))
+        return n_lambda
 
     def _create_lambda_field(self, lambda_min, lambda_max, n_lambda, units='angstrom'):
         """
@@ -927,7 +926,9 @@ class AbsorptionSpectrum(object):
         lf_max = comm.mpi_allreduce(my_max, op="max")
 
         if lf_min != np.inf:
-            n_lambda = self._get_field_size(lf_min, lf_max, self.bin_width) + 1
+            lf_min = np.round(lf_min / self.bin_width) * self.bin_width
+            lf_max = np.round(lf_max / self.bin_width) * self.bin_width
+            n_lambda = self._get_field_size(lf_min, lf_max, self.bin_width)
             new_lambda = self._create_lambda_field(lf_min, lf_max, n_lambda)
         else:
             new_lambda = None

--- a/trident/absorption_spectrum/absorption_spectrum.py
+++ b/trident/absorption_spectrum/absorption_spectrum.py
@@ -754,7 +754,7 @@ class AbsorptionSpectrum(object):
                 # window in the original spectrum's tau array
                 else:
                     intersect_left_index = max(left_index, 0)
-                    intersect_right_index = min(right_index, self.lambda_field.size-1)
+                    intersect_right_index = min(right_index, self.lambda_field.size)
                     EW_tau_deposit = EW_tau[(intersect_left_index - left_index): \
                                             (intersect_right_index - left_index)]
                     self.current_tau_field[intersect_left_index:intersect_right_index] \

--- a/trident/absorption_spectrum/absorption_spectrum.py
+++ b/trident/absorption_spectrum/absorption_spectrum.py
@@ -422,10 +422,10 @@ class AbsorptionSpectrum(object):
                                        observing_redshift=observing_redshift,
                                        min_tau=min_tau)
 
-        if self.tau_field is not None:
+        if self.tau_field is None:
+            mylog.warning('Spectrum is totally empty!')
+        else:
             self.flux_field = np.exp(-self.tau_field)
-
-        mylog.warning('Spectrum is totally empty!')
 
         if output_file is None:
             pass

--- a/trident/instrument.py
+++ b/trident/instrument.py
@@ -58,8 +58,11 @@ class Instrument(object):
             raise RuntimeError("Either n_lambda or dlambda must be set to "
                                "specify the binsize")
         elif dlambda is not None:
-            # adding 1 here to assure we cover full lambda range
-            n_lambda = (lambda_max - lambda_min) / float(dlambda) + 1
+            if lambda_min == 'auto' or lambda_max == 'auto':
+                n_lambda = 'auto'
+            else:
+                # adding 1 here to assure we cover full lambda range
+                n_lambda = (lambda_max - lambda_min) / float(dlambda) + 1
         self.n_lambda = n_lambda
         if dlambda is None:
             # adding 1 here to assure we cover full lambda range
@@ -69,9 +72,9 @@ class Instrument(object):
     def __repr__(self):
         disp = "<Instrument>:\n"
         disp += "    name: %s\n" % self.name
-        disp += "    lambda_min: %f\n" % self.lambda_min
-        disp += "    lambda_max: %f\n" % self.lambda_max
-        disp += "    n_lambda: %d\n" % self.n_lambda
-        disp += "    dlambda: %f\n" % self.dlambda
+        disp += "    lambda_min: %s\n" % self.lambda_min
+        disp += "    lambda_max: %s\n" % self.lambda_max
+        disp += "    n_lambda: %s\n" % self.n_lambda
+        disp += "    dlambda: %s\n" % self.dlambda
         disp += "    lsf_kernel: %s\n" % self.lsf_kernel
         return disp

--- a/trident/spectrum_generator.py
+++ b/trident/spectrum_generator.py
@@ -931,7 +931,7 @@ class SpectrumGenerator(AbsorptionSpectrum):
         elif format == 'ASCII':
             self._write_spectrum_ascii(filename)
         else:
-            mylog.warn("Invalid format.  Must be 'HDF5', 'FITS', 'ASCII'. Defaulting to ASCII.")
+            mylog.warning("Invalid format.  Must be 'HDF5', 'FITS', 'ASCII'. Defaulting to ASCII.")
             self._write_spectrum_ascii(filename)
 
     def plot_spectrum(self, filename="spectrum.png",
@@ -1011,6 +1011,11 @@ class SpectrumGenerator(AbsorptionSpectrum):
         >>> sg.make_spectrum(ray)
         >>> sg.plot_spectrum('spec_raw.png', features={'Ly a' : 1216})
         """
+
+        if self.tau_field is None:
+            mylog.warning('Spectrum is totally empty, no plotting to be done.')
+            return
+
         plot_spectrum(self.lambda_field, self.flux_field, filename=filename,
                       lambda_limits=lambda_limits, flux_limits=flux_limits,
                       title=title, label=label, figsize=figsize, step=step,

--- a/trident/spectrum_generator.py
+++ b/trident/spectrum_generator.py
@@ -180,8 +180,9 @@ class SpectrumGenerator(AbsorptionSpectrum):
     def __init__(self, instrument=None, lambda_min=None, lambda_max=None,
                  n_lambda=None, dlambda=None, lsf_kernel=None,
                  line_database='lines.txt', ionization_table=None):
-        if instrument is None and (lambda_min is None or
-                                   (dlambda is None and n_lambda is None)):
+        if instrument is None and \
+          ((lambda_min is None or lambda_max is None) or \
+           (dlambda is None and n_lambda is None)):
             instrument = 'COS'
             mylog.info("No parameters specified, defaulting to COS instrument.")
         elif instrument is None:

--- a/trident/spectrum_generator.py
+++ b/trident/spectrum_generator.py
@@ -95,15 +95,23 @@ class SpectrumGenerator(AbsorptionSpectrum):
         leave this set to None.
         Default: None
 
-    :lambda_min: int
+    :lambda_min: float or 'auto'
+
+        The wavelength extrema of the spectra in angstroms.
+        If set to 'auto', the lower bound will be automatically
+        adjusted to encompass all absorption lines. The wavelength
+        window will not be expanded for continuum features, only
+        absorption lines.
+        Default: None
+
+    :lambda_max: float or 'auto'
 
         The wavelength extrema of the spectra in angstroms
-        Defaults: None
-
-    :lambda_max: int
-
-        The wavelength extrema of the spectra in angstroms
-        Defaults: None
+        If set to 'auto', the upper bound will be automatically
+        adjusted to encompass all absorption lines. The wavelength
+        window will not be expanded for continuum features, only
+        absorption lines.
+        Default: None
 
     :n_lambda: int
 

--- a/trident/spectrum_generator.py
+++ b/trident/spectrum_generator.py
@@ -172,7 +172,7 @@ class SpectrumGenerator(AbsorptionSpectrum):
     def __init__(self, instrument=None, lambda_min=None, lambda_max=None,
                  n_lambda=None, dlambda=None, lsf_kernel=None,
                  line_database='lines.txt', ionization_table=None):
-        if instrument is None and lambda_min is None:
+        if instrument is None and (lambda_min is None or dlambda is None):
             instrument = 'COS'
             mylog.info("No parameters specified, defaulting to COS instrument.")
         elif instrument is None:
@@ -189,7 +189,8 @@ class SpectrumGenerator(AbsorptionSpectrum):
         AbsorptionSpectrum.__init__(self,
                                     self.instrument.lambda_min,
                                     self.instrument.lambda_max,
-                                    self.instrument.n_lambda)
+                                    n_lambda=self.instrument.n_lambda,
+                                    dlambda=self.instrument.dlambda)
 
         if isinstance(line_database, LineDatabase):
             self.line_database = line_database
@@ -787,9 +788,13 @@ class SpectrumGenerator(AbsorptionSpectrum):
         the AbsorptionSpectrum object as well.  Also clear the line_subset
         stored by the LineDatabase.
         """
-        # Set flux and tau to ones and zeros
-        self.flux_field = np.ones(self.lambda_field.size)
-        self.tau_field = np.zeros(self.lambda_field.size)
+        if self.lambda_field is not None:
+            # Set flux and tau to ones and zeros
+            self.flux_field = np.ones(self.lambda_field.size)
+            self.tau_field = np.zeros(self.lambda_field.size)
+        else:
+            self.flux_field = None
+            self.tau_field = None
 
         # Clear out the line list that is stored in AbsorptionSpectrum
         self.line_list = []

--- a/trident/spectrum_generator.py
+++ b/trident/spectrum_generator.py
@@ -180,7 +180,8 @@ class SpectrumGenerator(AbsorptionSpectrum):
     def __init__(self, instrument=None, lambda_min=None, lambda_max=None,
                  n_lambda=None, dlambda=None, lsf_kernel=None,
                  line_database='lines.txt', ionization_table=None):
-        if instrument is None and (lambda_min is None or dlambda is None):
+        if instrument is None and (lambda_min is None or
+                                   (dlambda is None and n_lambda is None)):
             instrument = 'COS'
             mylog.info("No parameters specified, defaulting to COS instrument.")
         elif instrument is None:


### PR DESCRIPTION
This adds new functionality that allows the user to set the lower and upper bounds of the wavelength range to 'auto' such that the `AbsorptionSpectrum` will automatically calculate bounds that fully encompass all absorption features. One can do:
```
sg = trident.SpectrumGenerator(lambda_min='auto', lambda_max='auto',
                               dlambda=0.01)
sg.make_spectrum("ray.h5", lines=['H I 1216', 'H I 1026'])
```
This will create a spectrum containing all Lya and Lyb lines. Either `lambda_min` or `lambda_max` can be set to hard limit as well, leaving just the other bound to vary.

This is a rather invasive change, so I've added extensive testing that compares 'auto' spectra with those made with hard limits under a variety of conditions. I've also added some tests of conditions where bad inputs are given to make sure we prohibit things instead of doing something crazy.