### PR TITLE
Add support for creating spectra in velocity space

### DIFF
--- a/doc/source/advanced_spectra.rst
+++ b/doc/source/advanced_spectra.rst
@@ -169,7 +169,7 @@ Making Spectra in Velocity Space
 --------------------------------
 
 Trident can be configured to create spectra in velocity space instead of
-wavelength spacem where velocity corresponds to the velocity offset from
+wavelength space where velocity corresponds to the velocity offset from
 the rest wavelength of a given line. This can be done by providing the
 keyword ``bin_space='velocity'`` to the :class:`~trident.SpectrumGenerator`::
 

--- a/doc/source/advanced_spectra.rst
+++ b/doc/source/advanced_spectra.rst
@@ -164,3 +164,22 @@ Note, the above example is for a different ray than is used in the
 previous examples. The resulting spectrum will minimally contain all
 absorption present in the ray. This should be used with care when depositing
 multiple lines as this can lead to an extremely large spectrum.
+
+Make Spectra in Velocity Space
+------------------------------
+
+Trident can be configured to create spectra in velocity space instead of
+wavelength spacem where velocity corresponds to the velocity offset from
+the rest wavelength of a given line. This can be done by providing the
+keyword ``bin_space='velocity'`` to the :class:`~trident.SpectrumGenerator`::
+
+    sg = trident.SpectrumGenerator(lambda_min='auto', lambda_max='auto',
+                                   dlambda=1., bin_space='velocity')
+    sg.make_spectrum("ray.h5", lines=['H I 1216'])
+    sg.plot_spectrum('spec_velocity.png')
+
+.. image:: https://raw.githubusercontent.com/trident-project/trident-docs-images/master/spec_velocity.png
+
+When working in velocity space, limits and bin sizes should be provided in km/s.
+If more than one transition is added to the spectrum (e.g., Ly-a and Ly-b), the
+zero point will correspond to the rest wavelength of the first transition added.

--- a/doc/source/advanced_spectra.rst
+++ b/doc/source/advanced_spectra.rst
@@ -165,8 +165,8 @@ previous examples. The resulting spectrum will minimally contain all
 absorption present in the ray. This should be used with care when depositing
 multiple lines as this can lead to an extremely large spectrum.
 
-Make Spectra in Velocity Space
-------------------------------
+Making Spectra in Velocity Space
+--------------------------------
 
 Trident can be configured to create spectra in velocity space instead of
 wavelength spacem where velocity corresponds to the velocity offset from
@@ -215,4 +215,3 @@ dataset::
                           label=['all gas', 'cold gas'], stagger=None)
 
 .. image:: https://raw.githubusercontent.com/trident-project/trident-docs-images/master/spec_cutregion.png
->>>>>>> master

--- a/tests/test_auto_lambda.py
+++ b/tests/test_auto_lambda.py
@@ -20,25 +20,11 @@ from trident import \
     SpectrumGenerator
 from trident.testing import \
     answer_test_data_dir, \
+    compare_spectra, \
     TempDirTest
 
 COSMO_PLUS_SINGLE = os.path.join(answer_test_data_dir,
                                  "enzo_cosmology_plus/RD0009/RD0009")
-
-def compare_spectra(sg1, sg2, comp_key):
-    assert_allclose(
-        sg1.tau_field, sg2.tau_field, rtol=1e-6,
-        err_msg='tau arrays for auto and %s disagree!' % comp_key)
-    assert_allclose(
-        sg1.lambda_field, sg2.lambda_field, rtol=1e-10,
-        err_msg='lambda arrays for auto and %s disagree!' % comp_key)
-
-    for my_line in sg1.line_observables_dict:
-        for key in sg1.line_observables_dict[my_line]:
-            assert_allclose(
-                sg1.line_observables_dict[my_line][key],
-                sg2.line_observables_dict[my_line][key], rtol=1e-7,
-                err_msg='%s field for auto and %s disagree!' % (key, comp_key))
 
 class AutoLambdaTest(TempDirTest):
 

--- a/tests/test_velocity_space.py
+++ b/tests/test_velocity_space.py
@@ -1,5 +1,5 @@
 """
-tests for auto-lambda feature
+tests for velocity bin space
 """
 
 #-----------------------------------------------------------------------------
@@ -26,10 +26,10 @@ from trident.testing import \
 COSMO_PLUS_SINGLE = os.path.join(answer_test_data_dir,
                                  "enzo_cosmology_plus/RD0009/RD0009")
 
-class AutoLambdaTest(TempDirTest):
+class VelocitySpaceTest(TempDirTest):
 
     def setUp(self):
-        super(AutoLambdaTest, self).setUp()
+        super(VelocitySpaceTest, self).setUp()
         ds = load(COSMO_PLUS_SINGLE)
         line_list = ['H I 1216', 'H I 1026']
 
@@ -41,58 +41,61 @@ class AutoLambdaTest(TempDirTest):
 
     def test_dlambda(self):
         """
-        Compare auto wavelength against setting same min, max, and dlambda
+        Compare auto velocity against setting same min, max, and dlambda
         """
 
         sg_auto = SpectrumGenerator(
             lambda_min='auto', lambda_max='auto',
-            dlambda=0.01)
+            dlambda=1.0, bin_space='velocity')
         sg_auto.make_spectrum("ray.h5", lines=self.line_list,
                               store_observables=True)
 
         sg_comp = SpectrumGenerator(
             lambda_min=sg_auto.lambda_field[0],
             lambda_max=sg_auto.lambda_field[-1],
-            dlambda=sg_auto.bin_width)
+            dlambda=sg_auto.bin_width,
+            bin_space='velocity')
         sg_comp.make_spectrum("ray.h5", lines=self.line_list,
                               store_observables=True)
         compare_spectra(sg_auto, sg_comp, 'manually setting dlambda')
 
     def test_n_lambda(self):
         """
-        Compare auto wavelength against setting same min, max, and n_lambda
+        Compare auto velocity against setting same min, max, and n_lambda
         """
 
         sg_auto = SpectrumGenerator(
             lambda_min='auto', lambda_max='auto',
-            dlambda=0.01)
+            dlambda=1.0, bin_space='velocity')
         sg_auto.make_spectrum("ray.h5", lines=self.line_list,
                               store_observables=True)
 
         sg_comp = SpectrumGenerator(
             lambda_min=sg_auto.lambda_field[0],
             lambda_max=sg_auto.lambda_field[-1],
-            n_lambda=sg_auto.lambda_field.size)
+            n_lambda=sg_auto.lambda_field.size,
+            bin_space='velocity')
         sg_comp.make_spectrum("ray.h5", lines=self.line_list,
                               store_observables=True)
         compare_spectra(sg_auto, sg_comp, 'manually setting n_lambda')
 
     def test_dlambda_extra_wide(self):
         """
-        Compare auto wavelength against setting same dlambda with
+        Compare auto velocity against setting same dlambda with
         min and max set extra wide.
         """
 
         sg_auto = SpectrumGenerator(
             lambda_min='auto', lambda_max='auto',
-            dlambda=0.01)
+            dlambda=1.0, bin_space='velocity')
         sg_auto.make_spectrum("ray.h5", lines=self.line_list,
                               store_observables=True)
 
         sg_comp = SpectrumGenerator(
             lambda_min=sg_auto.lambda_field[0],
             lambda_max=sg_auto.lambda_field[-1],
-            n_lambda=sg_auto.lambda_field.size)
+            n_lambda=sg_auto.lambda_field.size,
+            bin_space='velocity')
         sg_comp.make_spectrum("ray.h5", lines=self.line_list,
                               store_observables=True)
 
@@ -106,9 +109,10 @@ class AutoLambdaTest(TempDirTest):
         Test we can make an empty spectrum without crashing.
         """
 
-        sg = SpectrumGenerator(lambda_max=1100,
-                               lambda_min='auto',
-                               dlambda=0.01)
+        sg = SpectrumGenerator(lambda_min=3000,
+                               lambda_max='auto',
+                               dlambda=1.0,
+                               bin_space='velocity')
         sg.make_spectrum("ray.h5", lines=['H I 1216'],
                          output_file='blank.h5',
                          output_absorbers_file='blank.txt',
@@ -125,13 +129,13 @@ class AutoLambdaTest(TempDirTest):
 
         sg_auto = SpectrumGenerator(
             lambda_min='auto', lambda_max='auto',
-            dlambda=0.01)
+            dlambda=1.0, bin_space='velocity')
         sg_auto.make_spectrum("ray.h5", lines=self.line_list,
                               ly_continuum=False)
 
         sg_comp = SpectrumGenerator(
-            lambda_min=1100, lambda_max='auto',
-            dlambda=0.01)
+            lambda_min=0., lambda_max='auto',
+            dlambda=1.0, bin_space='velocity')
         sg_comp.make_spectrum("ray.h5", lines=self.line_list,
                               ly_continuum=False)
 
@@ -148,13 +152,13 @@ class AutoLambdaTest(TempDirTest):
 
         sg_auto = SpectrumGenerator(
             lambda_min='auto', lambda_max='auto',
-            dlambda=0.01)
+            dlambda=1.0, bin_space='velocity')
         sg_auto.make_spectrum("ray.h5", lines=self.line_list,
                               ly_continuum=False)
 
         sg_comp = SpectrumGenerator(
-            lambda_min='auto', lambda_max=1100,
-            dlambda=0.01)
+            lambda_min='auto', lambda_max=0.,
+            dlambda=1.0, bin_space='velocity')
         sg_comp.make_spectrum("ray.h5", lines=self.line_list,
                               ly_continuum=False)
 

--- a/trident/absorption_spectrum/absorption_spectrum.py
+++ b/trident/absorption_spectrum/absorption_spectrum.py
@@ -101,10 +101,11 @@ class AbsorptionSpectrum(object):
                 'Invalid bin_space value: "%s". Valid values are: "%s".' %
                 (bin_space, '", "'.join(list(_bin_space_units))))
         self.bin_space = bin_space
+        lunits = _bin_space_units[self.bin_space]
 
         if dlambda is not None:
             if not isinstance(dlambda, YTQuantity):
-                dlambda = YTQuantity(dlambda, _bin_space_units[self.bin_space])
+                dlambda = YTQuantity(dlambda, lunits)
             self.bin_width = dlambda
 
         if n_lambda is None and dlambda is None:
@@ -116,7 +117,7 @@ class AbsorptionSpectrum(object):
         if str(lambda_min) != 'auto':
             if not isinstance(lambda_min, YTQuantity):
                 lambda_min = YTQuantity(
-                    lambda_min, _bin_space_units[self.bin_space])
+                    lambda_min, lunits)
             # round limits to bin size
             if dlambda is not None:
                 lambda_min = np.round(lambda_min / dlambda) * dlambda
@@ -125,7 +126,7 @@ class AbsorptionSpectrum(object):
         if str(lambda_max) != 'auto':
             if not isinstance(lambda_max, YTQuantity):
                 lambda_max = YTQuantity(
-                    lambda_max, _bin_space_units[self.bin_space])
+                    lambda_max, lunits)
             # round limits to bin size
             if dlambda is not None:
                 lambda_max = np.round(lambda_max / dlambda) * dlambda
@@ -139,7 +140,7 @@ class AbsorptionSpectrum(object):
                 'Cannot set n_lambda when setting lambda_min or lambda_max to auto.')
 
         if dlambda is not None:
-            self.bin_width = YTQuantity(dlambda, 'angstrom')
+            self.bin_width = YTQuantity(dlambda, lunits)
             if not self._auto_lambda:
                 n_lambda = \
                   self._get_field_size(self.lambda_min, self.lambda_max,
@@ -157,7 +158,7 @@ class AbsorptionSpectrum(object):
                 n_lambda = int(n_lambda)
                 self.bin_width = YTQuantity(
                     float(lambda_max - lambda_min) / (n_lambda - 1),
-                    _bin_space_units[self.bin_space])
+                    lunits)
             else:
                 n_lambda = \
                   self._get_field_size(self.lambda_min, self.lambda_max,

--- a/trident/absorption_spectrum/absorption_spectrum.py
+++ b/trident/absorption_spectrum/absorption_spectrum.py
@@ -99,7 +99,7 @@ class AbsorptionSpectrum(object):
         if n_lambda is not None and dlambda is not None:
             n_lambda = None
 
-        if lambda_min != 'auto':
+        if str(lambda_min) != 'auto':
             if not isinstance(lambda_min, YTQuantity):
                 lambda_min = YTQuantity(
                     lambda_min, _bin_space_units[self.bin_space])
@@ -108,7 +108,7 @@ class AbsorptionSpectrum(object):
                 lambda_min = np.round(lambda_min / dlambda) * dlambda
         self.lambda_min = lambda_min
 
-        if lambda_max != 'auto':
+        if str(lambda_max) != 'auto':
             if not isinstance(lambda_max, YTQuantity):
                 lambda_max = YTQuantity(
                     lambda_max, _bin_space_units[self.bin_space])

--- a/trident/absorption_spectrum/absorption_spectrum.py
+++ b/trident/absorption_spectrum/absorption_spectrum.py
@@ -57,26 +57,28 @@ class AbsorptionSpectrum(object):
 
     :lambda_min: float, YTQuantity, or 'auto'
 
-       lower wavelength bound in angstroms. If set to 'auto', the lower
+       lower wavelength bound in angstroms or velocity bound in km/s
+       (if bin_space set to 'velocity'). If set to 'auto', the lower
        bound will be automatically adjusted to encompass all absorption
-       lines. The wavelength window will not be expanded for continuum
-       features, only absorption lines.
+       lines. The window will not be expanded for continuum features,
+       only absorption lines.
 
     :lambda_max: float, YTQuantity, or 'auto'
 
-       upper wavelength bound in angstroms. If set to 'auto', the upper
+       upper wavelength bound in angstroms or velocity bound in km/s
+       (if bin_space set to 'velocity'). If set to 'auto', the upper
        bound will be automatically adjusted to encompass all absorption
-       lines. The wavelength window will not be expanded for continuum
-       features, only absorption lines.
+       lines. The window will not be expanded for continuum features,
+       only absorption lines.
 
     :n_lambda: optional, int
 
-       number of wavelength bins. This cannot be set when setting
-       either lambda_min or lambda_max to auto.
+       number of bins. This cannot be set when setting either lambda_min
+       or lambda_max to auto.
 
     :dlambda: optional, float or YTQuantity
 
-      size of the wavelength bins in angstroms.
+      size of the wavelength bins in angstroms or velocity bins in km/s.
 
     :bin_space: 'wavelength' or 'velocity'
 

--- a/trident/absorption_spectrum/absorption_spectrum.py
+++ b/trident/absorption_spectrum/absorption_spectrum.py
@@ -120,7 +120,7 @@ class AbsorptionSpectrum(object):
             if not self._auto_lambda:
                 n_lambda = \
                   self._get_field_size(self.lambda_min, self.lambda_max,
-                                       self.bin_width, do_round=True)
+                                       self.bin_width)
 
         if self._auto_lambda:
             self.lambda_field = None
@@ -144,7 +144,7 @@ class AbsorptionSpectrum(object):
         self.continuum_list = []
         self.snr = 100  # default signal to noise ratio for error estimation
 
-    def _get_field_size(self, lambda_min, lambda_max, dlambda, do_round=False):
+    def _get_field_size(self, lambda_min, lambda_max, dlambda):
         """
         Calculate number of bins.
         """
@@ -165,9 +165,8 @@ class AbsorptionSpectrum(object):
             my_dlambda = dlambda
 
         n_lambda = (my_max - my_min) / my_dlambda + 1
-        if do_round:
-            n_lambda = np.round(n_lambda)
-        return int(n_lambda)
+        n_lambda = int(np.round(n_lambda))
+        return n_lambda
 
     def _create_lambda_field(self, lambda_min, lambda_max, n_lambda,
                              units=None):
@@ -1001,7 +1000,9 @@ class AbsorptionSpectrum(object):
         lf_max = comm.mpi_allreduce(my_max, op="max")
 
         if lf_min != np.inf:
-            n_lambda = self._get_field_size(lf_min, lf_max, self.bin_width) + 1
+            lf_min = np.round(lf_min / self.bin_width) * self.bin_width
+            lf_max = np.round(lf_max / self.bin_width) * self.bin_width
+            n_lambda = self._get_field_size(lf_min, lf_max, self.bin_width)
             new_lambda = self._create_lambda_field(lf_min, lf_max, n_lambda)
         else:
             new_lambda = None

--- a/trident/absorption_spectrum/absorption_spectrum.py
+++ b/trident/absorption_spectrum/absorption_spectrum.py
@@ -77,6 +77,14 @@ class AbsorptionSpectrum(object):
     :dlambda: optional, float or YTQuantity
 
       size of the wavelength bins in angstroms.
+
+    :bin_space: 'wavelength' or 'velocity'
+
+        Sets the dimension in which spectra are created. If set to
+        wavelength, the resulting spectra are flux (or tau) vs. observed
+        wavelength. If set to velocity, the spectra are flux vs.
+        velocity offset from the rest wavelength of the absorption line.
+        Default: wavelength
     """
 
     def __init__(self, lambda_min, lambda_max, n_lambda=None, dlambda=None,

--- a/trident/absorption_spectrum/absorption_spectrum.py
+++ b/trident/absorption_spectrum/absorption_spectrum.py
@@ -961,6 +961,8 @@ class AbsorptionSpectrum(object):
                             "lambda_obs":lambda_obs,
                             "thermal_b":thermal_b,
                             "thermal_width":thermal_width}
+                if self.bin_space == 'velocity':
+                    obs_dict['velocity_offset'] = my_obs
                 store.result_id = line['label']
                 store.result = obs_dict
                 ## Can only delete these if in this statement:
@@ -969,7 +971,7 @@ class AbsorptionSpectrum(object):
             self.current_tau_field = None
 
             # These always need to be deleted
-            del column_density, delta_lambda, lambda_obs, \
+            del column_density, delta_lambda, lambda_obs, my_obs, \
                 thermal_b, thermal_width, cdens, thermb, dlambda, \
                 vlos, resolution, vbin_width, n_vbins, n_vbins_per_bin
 

--- a/trident/absorption_spectrum/absorption_spectrum.py
+++ b/trident/absorption_spectrum/absorption_spectrum.py
@@ -422,10 +422,10 @@ class AbsorptionSpectrum(object):
                                        observing_redshift=observing_redshift,
                                        min_tau=min_tau)
 
-        if self.tau_field is not None:
+        if self.tau_field is None:
+            mylog.warning('Spectrum is totally empty!')
+        else:
             self.flux_field = np.exp(-self.tau_field)
-
-        mylog.warning('Spectrum is totally empty!')
 
         if output_file is None:
             pass

--- a/trident/instrument.py
+++ b/trident/instrument.py
@@ -60,11 +60,11 @@ class Instrument(object):
 
         self.bin_space = bin_space
 
-        if lambda_min != 'auto' and not isinstance(lambda_min, YTQuantity):
+        if str(lambda_min) != 'auto' and not isinstance(lambda_min, YTQuantity):
             lambda_min = YTQuantity(lambda_min, _bin_space_units[self.bin_space])
         self.lambda_min = lambda_min
 
-        if lambda_max != 'auto' and not isinstance(lambda_max, YTQuantity):
+        if str(lambda_max) != 'auto' and not isinstance(lambda_max, YTQuantity):
             lambda_max = YTQuantity(lambda_max, _bin_space_units[self.bin_space])
         self.lambda_max = lambda_max
 
@@ -76,7 +76,7 @@ class Instrument(object):
         elif dlambda is not None:
             if not isinstance(dlambda, YTQuantity):
                 dlambda = YTQuantity(dlambda, _bin_space_units[self.bin_space])
-            if lambda_min == 'auto' or lambda_max == 'auto':
+            if str(lambda_min) == 'auto' or str(lambda_max) == 'auto':
                 n_lambda = 'auto'
             else:
                 # adding 1 here to assure we cover full lambda range

--- a/trident/plotting.py
+++ b/trident/plotting.py
@@ -18,6 +18,9 @@ import matplotlib.figure
 from matplotlib.backends.backend_agg import \
     FigureCanvasAgg
 
+_xlabels = {'angstrom': 'Wavelength [$\\rm\\AA$]',
+            'km/s': 'Velocity [km/s]'}
+
 def plot_spectrum(wavelength, flux, filename="spectrum.png",
                   lambda_limits=None, flux_limits=None,
                   title=None, label=None, figsize=None, step=False,
@@ -204,6 +207,8 @@ def plot_spectrum(wavelength, flux, filename="spectrum.png",
     # A running maximum of flux for use in ylim scaling in final plot
     max_flux = 0.
 
+    xlabel = _xlabels[str(wavelength.units)]
+
     for i, (wavelength, flux) in enumerate(zip(wavelengths, fluxs)):
 
         # Do we stagger the fluxes?
@@ -237,7 +242,7 @@ def plot_spectrum(wavelength, flux, filename="spectrum.png",
         flux_limits = (0, 1.1*max_flux)
     my_axes.set_ylim(flux_limits[0], flux_limits[1])
     if axis_labels is None:
-        axis_labels = ('Wavelength [$\\rm\\AA$]', 'Relative Flux')
+        axis_labels = (xlabel, 'Relative Flux')
     my_axes.xaxis.set_label_text(axis_labels[0])
     my_axes.yaxis.set_label_text(axis_labels[1])
 

--- a/trident/plotting.py
+++ b/trident/plotting.py
@@ -19,7 +19,7 @@ from matplotlib.backends.backend_agg import \
     FigureCanvasAgg
 
 _xlabels = {'angstrom': 'Wavelength [$\\rm\\AA$]',
-            'km/s': 'Velocity [km/s]'}
+            'km/s': 'Velocity Offset [km/s]'}
 
 def plot_spectrum(wavelength, flux, filename="spectrum.png",
                   lambda_limits=None, flux_limits=None,
@@ -207,7 +207,11 @@ def plot_spectrum(wavelength, flux, filename="spectrum.png",
     # A running maximum of flux for use in ylim scaling in final plot
     max_flux = 0.
 
-    xlabel = _xlabels[str(wavelength.units)]
+    if isinstance(wavelength, list):
+        key = wavelength[0]
+    else:
+        key = wavelength
+    xlabel = _xlabels.get(str(key.units))
 
     for i, (wavelength, flux) in enumerate(zip(wavelengths, fluxs)):
 

--- a/trident/spectrum_generator.py
+++ b/trident/spectrum_generator.py
@@ -179,7 +179,8 @@ class SpectrumGenerator(AbsorptionSpectrum):
     """
     def __init__(self, instrument=None, lambda_min=None, lambda_max=None,
                  n_lambda=None, dlambda=None, lsf_kernel=None,
-                 line_database='lines.txt', ionization_table=None):
+                 line_database='lines.txt', ionization_table=None,
+                 bin_space='wavelength'):
         if instrument is None and (lambda_min is None or
                                    (dlambda is None and n_lambda is None)):
             instrument = 'COS'
@@ -199,7 +200,8 @@ class SpectrumGenerator(AbsorptionSpectrum):
                                     self.instrument.lambda_min,
                                     self.instrument.lambda_max,
                                     n_lambda=self.instrument.n_lambda,
-                                    dlambda=self.instrument.dlambda)
+                                    dlambda=self.instrument.dlambda,
+                                    bin_space=bin_space)
 
         if isinstance(line_database, LineDatabase):
             self.line_database = line_database

--- a/trident/spectrum_generator.py
+++ b/trident/spectrum_generator.py
@@ -95,33 +95,31 @@ class SpectrumGenerator(AbsorptionSpectrum):
         leave this set to None.
         Default: None
 
-    :lambda_min: float or 'auto'
+    :lambda_min: float, YTQuantity, or 'auto'
 
-        The wavelength extrema of the spectra in angstroms.
-        If set to 'auto', the lower bound will be automatically
-        adjusted to encompass all absorption lines. The wavelength
-        window will not be expanded for continuum features, only
-        absorption lines.
-        Default: None
+       lower wavelength bound in angstroms or velocity bound in km/s
+       (if bin_space set to 'velocity'). If set to 'auto', the lower
+       bound will be automatically adjusted to encompass all absorption
+       lines. The window will not be expanded for continuum features,
+       only absorption lines.
 
-    :lambda_max: float or 'auto'
+    :lambda_max: float, YTQuantity, or 'auto'
 
-        The wavelength extrema of the spectra in angstroms
-        If set to 'auto', the upper bound will be automatically
-        adjusted to encompass all absorption lines. The wavelength
-        window will not be expanded for continuum features, only
-        absorption lines.
-        Default: None
+       upper wavelength bound in angstroms or velocity bound in km/s
+       (if bin_space set to 'velocity'). If set to 'auto', the upper
+       bound will be automatically adjusted to encompass all absorption
+       lines. The window will not be expanded for continuum features,
+       only absorption lines.
 
     :n_lambda: int
 
-        The number of wavelength bins in the spectrum (inclusive), so if
+        The number of bins in the spectrum (inclusive), so if
         extrema = 10 and 20, and dlambda (binsize) = 1, then n_lambda = 11.
         Default: None
 
     :dlambda: float
 
-        The desired wavelength bin width of the spectrum (in angstroms).
+        size of the wavelength bins in angstroms or velocity bins in km/s.
         Default: None
 
     :bin_space: 'wavelength' or 'velocity'

--- a/trident/spectrum_generator.py
+++ b/trident/spectrum_generator.py
@@ -190,7 +190,8 @@ class SpectrumGenerator(AbsorptionSpectrum):
                                     lambda_max=lambda_max,
                                     n_lambda=n_lambda,
                                     dlambda=dlambda,
-                                    lsf_kernel=lsf_kernel, name="Custom")
+                                    lsf_kernel=lsf_kernel, name="Custom",
+                                    bin_space=bin_space)
         self.observing_redshift = 0.
         self._set_instrument(instrument)
         mylog.info("Setting instrument to %s" % self.instrument.name)

--- a/trident/spectrum_generator.py
+++ b/trident/spectrum_generator.py
@@ -124,6 +124,14 @@ class SpectrumGenerator(AbsorptionSpectrum):
         The desired wavelength bin width of the spectrum (in angstroms).
         Default: None
 
+    :bin_space: 'wavelength' or 'velocity'
+
+        Sets the dimension in which spectra are created. If set to
+        wavelength, the resulting spectra are flux (or tau) vs. observed
+        wavelength. If set to velocity, the spectra are flux vs.
+        velocity offset from the rest wavelength of the absorption line.
+        Default: wavelength
+
     :lsf_kernel: string, optional
 
         The filename for the LSF kernel. Files are found in

--- a/trident/testing.py
+++ b/trident/testing.py
@@ -13,6 +13,7 @@ Testing utilities for Trident
 
 import h5py
 from numpy.testing import \
+    assert_allclose, \
     assert_array_equal
 import os
 import shutil
@@ -106,3 +107,22 @@ def assert_array_rel_equal(a1, a2, decimals=16, **kwargs):
     Wraps assert_rel_equal with, but decimals is a keyword arg.
     """
     assert_rel_equal(a1, a2, decimals, **kwargs)
+
+
+def compare_spectra(sg1, sg2, comp_key):
+    """
+    Compare two spectra.
+    """
+    assert_allclose(
+        sg1.tau_field, sg2.tau_field, rtol=1e-7,
+        err_msg='tau arrays for auto and %s disagree!' % comp_key)
+    assert_allclose(
+        sg1.lambda_field, sg2.lambda_field, rtol=1e-10,
+        err_msg='lambda arrays for auto and %s disagree!' % comp_key)
+
+    for my_line in sg1.line_observables_dict:
+        for key in sg1.line_observables_dict[my_line]:
+            assert_allclose(
+                sg1.line_observables_dict[my_line][key],
+                sg2.line_observables_dict[my_line][key], rtol=1e-7,
+                err_msg='%s field for auto and %s disagree!' % (key, comp_key))


### PR DESCRIPTION
This allows the user to make velocity-space spectra by setting the `bin_space='velocity'` keyword in the `SpectrumGenerator`. By doing this, one gets a spectrum that looks something like this:
![spec_v1](https://user-images.githubusercontent.com/5639935/62295037-2317c380-b464-11e9-9b4a-b5ed80fb3cae.png)

This PR builds on PR #87, so that should probably be merged first. The changes between that PR and this are actually quite small in comparison.

One thing to be resolved is the following: Is it worth changing all of the variable names from `lambda_<something>` to something more general? I elected not to do that here so as to keep the diff small, but maybe it's worth doing at some point, but probably not before this branch is merged with the `sph-viz` branch.