### PR TITLE
Add ability to make spectrum from data container.

### DIFF
--- a/doc/source/advanced_spectra.rst
+++ b/doc/source/advanced_spectra.rst
@@ -142,3 +142,35 @@ Giving us:
 To understand how to further customize your spectra, look at the documentation 
 for the :class:`~trident.SpectrumGenerator` and :class:`~trident.LineDatabase`
 classes and other :ref:`API <api-reference>` documentation.
+
+Making Spectra from a Subset of a Ray
+-------------------------------------
+
+The situation may arise where you want to see the spectrum that is generated
+by only a portion of the gas along a line of sight. For example, you may want to
+see the spectrum of only the cold gas. This can be done by creating a
+:class:`~yt.data_objects.selection_data_containers.YTCutRegion` from a loaded ray
+dataset::
+
+    import trident
+    import yt
+
+    ds = yt.load('ray.h5')
+    all_data = ds.all_data()
+    cold_gas = ds.cut_region(all_data, 'obj["gas", "temperature"] < 10000')
+
+    sg = trident.SpectrumGenerator(lambda_min=1200, lambda_max=1225,
+                                   dlambda=0.01)
+
+    # spectrum of entire ray
+    sg.make_spectrum(all_data, lines=['H I 1216'])
+    all_spectrum = sg.flux_field[:]
+
+    # spectrum of cold gas
+    sg.make_spectrum(cold_gas, lines=['H I 1216'])
+    cold_spectrum = sg.flux_field[:]
+
+    trident.plot_spectrum(sg.lambda_field, [all_spectrum, cold_spectrum],
+                          label=['all gas', 'cold gas'], stagger=None)
+
+.. image:: https://raw.githubusercontent.com/trident-project/trident-docs-images/master/spec_cutregion.png

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -34,10 +34,14 @@ import glob
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
+    'sphinx.ext.intersphinx',
     'sphinx.ext.napoleon',
     'sphinx.ext.viewcode',
     'sphinx.ext.imgmath',
 ]
+
+intersphinx_mapping = \
+  {'yt': ('http://yt-project.org/docs/dev/', None),}
 
 autosummary_generate = glob.glob("reference.rst")
 

--- a/trident/absorption_spectrum/absorption_spectrum.py
+++ b/trident/absorption_spectrum/absorption_spectrum.py
@@ -157,7 +157,7 @@ class AbsorptionSpectrum(object):
                                     'normalization': normalization,
                                     'index': index})
 
-    def make_spectrum(self, input_file, output_file=None,
+    def make_spectrum(self, input_object, output_file=None,
                       line_list_file=None, output_absorbers_file=None,
                       use_peculiar_velocity=True,
                       store_observables=False,
@@ -168,9 +168,12 @@ class AbsorptionSpectrum(object):
 
         **Parameters**
 
-        :input_file: string or dataset
+        :input_object: string, dataset, or data container
 
-           path to input ray data or a loaded ray dataset
+           If a string, the path to the ray dataset. As a dataset,
+           this is the ray dataset loaded by yt. As a data container,
+           this is a data object created from a ray dataset, such as
+           a cut region.
 
         :output_file: optional, string
 
@@ -270,22 +273,22 @@ class AbsorptionSpectrum(object):
                 input_fields.append(feature['field_name'])
                 field_units[feature["field_name"]] = "cm**-3"
 
-        if isinstance(input_file, string_types):
-            input_ds = load(input_file)
+        if isinstance(input_object, string_types):
+            input_ds = load(input_object)
             field_data = input_ds.all_data()
-        elif isinstance(input_file, Dataset):
-            input_ds = input_file
+        elif isinstance(input_object, Dataset):
+            input_ds = input_object
             field_data = input_ds.all_data()
-        elif isinstance(input_file, YTDataContainer):
-            input_ds = input_file.ds
-            field_data = input_file
+        elif isinstance(input_object, YTDataContainer):
+            input_ds = input_object.ds
+            field_data = input_object
 
         # temperature field required to calculate voigt profile widths
         if ('temperature' not in input_ds.derived_field_list) and \
            (('gas', 'temperature') not in input_ds.derived_field_list):
             raise RuntimeError(
                 "('gas', 'temperature') field required to be present in %s "
-                "for AbsorptionSpectrum to function." % input_file)
+                "for AbsorptionSpectrum to function." % str(input_object))
 
         self.tau_field = np.zeros(self.lambda_field.size)
         self.absorbers_list = []

--- a/trident/absorption_spectrum/absorption_spectrum.py
+++ b/trident/absorption_spectrum/absorption_spectrum.py
@@ -22,6 +22,10 @@ import numpy as np
 from trident.absorption_spectrum.absorption_line import \
     tau_profile
 
+from yt.data_objects.data_containers import \
+    YTDataContainer
+from yt.data_objects.static_output import \
+    Dataset
 from yt.extern.six import string_types
 from yt.convenience import load
 from yt.funcs import get_pbar, mylog
@@ -268,9 +272,13 @@ class AbsorptionSpectrum(object):
 
         if isinstance(input_file, string_types):
             input_ds = load(input_file)
-        else:
+            field_data = input_ds.all_data()
+        elif isinstance(input_file, Dataset):
             input_ds = input_file
-        field_data = input_ds.all_data()
+            field_data = input_ds.all_data()
+        elif isinstance(input_file, YTDataContainer):
+            input_ds = input_file.ds
+            field_data = input_file
 
         # temperature field required to calculate voigt profile widths
         if ('temperature' not in input_ds.derived_field_list) and \

--- a/trident/plotting.py
+++ b/trident/plotting.py
@@ -184,28 +184,30 @@ def plot_spectrum(wavelength, flux, filename="spectrum.png",
     my_axes = figure.add_axes((left_side, bottom_side, panel_width, panel_height))
 
     # Are we overplotting several spectra?  or just one?
-    if not (isinstance(wavelength, list) and isinstance(flux, list)):
-        wavelengths = [wavelength]
-        fluxs = [flux]
-        labels = [label]
-        steps = [step]
-    else:
-        wavelengths = wavelength
+    if isinstance(flux, list):
         fluxs = flux
-        if label is not None:
-            labels = label
-        else:
-            labels = [None]*len(fluxs)
-        if step is not None:
-            steps = step
-        else:
-            steps = [None]*len(fluxs)
+    else:
+        fluxs = [flux]
+
+    if isinstance(wavelength, list):
+        wavelengths = wavelength
+    else:
+        wavelengths = [wavelength]*len(fluxs)
+
+    if isinstance(step, list):
+        steps = step
+    else:
+        steps = [step]*len(fluxs)
+
+    if isinstance(label, list):
+        labels = label
+    else:
+        labels = [label]*len(fluxs)
 
     # A running maximum of flux for use in ylim scaling in final plot
     max_flux = 0.
 
     for i, (wavelength, flux) in enumerate(zip(wavelengths, fluxs)):
-
         # Do we stagger the fluxes?
         if stagger is not None:
             flux -= stagger * i

--- a/trident/spectrum_generator.py
+++ b/trident/spectrum_generator.py
@@ -18,6 +18,10 @@ from trident.absorption_spectrum.absorption_spectrum import \
     AbsorptionSpectrum
 from yt.convenience import \
     load
+from yt.data_objects.data_containers import \
+    YTDataContainer
+from yt.data_objects.static_output import \
+    Dataset
 from yt.funcs import \
     mylog, \
     YTArray
@@ -334,7 +338,13 @@ class SpectrumGenerator(AbsorptionSpectrum):
 
         if isinstance(ray, str):
             ray = load(ray)
-        ad = ray.all_data()
+        if isinstance(ray, Dataset):
+            ad = ray.all_data()
+        elif isinstance(ray, YTDataContainer):
+            ad = ray
+            ray = ad.ds
+        else:
+            raise RuntimeError("Unrecognized ray type.")
 
         # Clear out any previous spectrum that existed first
         self.clear_spectrum()
@@ -396,7 +406,7 @@ class SpectrumGenerator(AbsorptionSpectrum):
         if len(H_lines) > 0 and ly_continuum:
             self.add_continuum('Ly C', H_lines[0].field, 912.32336, 1.6e17, 3.0)
 
-        AbsorptionSpectrum.make_spectrum(self, ray,
+        AbsorptionSpectrum.make_spectrum(self, ad,
                                          output_file=None,
                                          line_list_file=None,
                                          output_absorbers_file=output_absorbers_file,

--- a/trident/spectrum_generator.py
+++ b/trident/spectrum_generator.py
@@ -236,9 +236,12 @@ class SpectrumGenerator(AbsorptionSpectrum):
 
         **Parameters**
 
-        :ray: string or dataset
+        :ray: string, dataset, or data container
 
-            Ray dataset filename or a loaded ray dataset
+            If a string, the path to the ray dataset. As a dataset,
+            this is the ray dataset loaded by yt. As a data container,
+            this is a data object created from a ray dataset, such as
+            a cut region.
 
         :lines: list of strings
 


### PR DESCRIPTION
This adds the ability to make spectra from data containers derived from ray datasets, such as `all_data()` or a `cut_region`. Docs and tests added. This also corrects some minor issues with plotting multiple spectra with the `plot_spectrum` command.