### PR TITLE
Logging info doesn't use correct units

### DIFF
--- a/trident/absorption_spectrum/absorption_spectrum.py
+++ b/trident/absorption_spectrum/absorption_spectrum.py
@@ -781,7 +781,7 @@ class AbsorptionSpectrum(object):
             if (my_width < self.bin_width).any():
                 mylog.info("%d out of %d line components will be " +
                             "deposited as unresolved lines.",
-                            (thermal_width < self.bin_width).sum(),
+                            (my_width < self.bin_width).sum(),
                             n_absorbers)
 
             # Keep track of the lambda field before depositing a new line


### PR DESCRIPTION
This looks like a small bug from the addition of velocities. In the logging info it tries to compare `thermal_width` (which is in angstroms) to `self.bin_width` (which can be in km/s). YT then complains and the program crashes. This only occurs of course if you set the resolution relatively high. 

Changing to `my_width` (like in the if statement above) fixes things nicely so that the units always match.

I tried to search through and didn't find any other case where `thermal_width` was still being used incorrectly. 