### PR TITLE
[bugfix] Shift wavelength of velocity center to redshift from light ray solution.

### DIFF
--- a/tests/test_velocity_space.py
+++ b/tests/test_velocity_space.py
@@ -134,7 +134,7 @@ class VelocitySpaceTest(TempDirTest):
                               ly_continuum=False)
 
         sg_comp = SpectrumGenerator(
-            lambda_min=0., lambda_max='auto',
+            lambda_min=-10000., lambda_max='auto',
             dlambda=1.0, bin_space='velocity')
         sg_comp.make_spectrum("ray.h5", lines=self.line_list,
                               ly_continuum=False)
@@ -157,7 +157,7 @@ class VelocitySpaceTest(TempDirTest):
                               ly_continuum=False)
 
         sg_comp = SpectrumGenerator(
-            lambda_min='auto', lambda_max=0.,
+            lambda_min='auto', lambda_max=-10000.,
             dlambda=1.0, bin_space='velocity')
         sg_comp.make_spectrum("ray.h5", lines=self.line_list,
                               ly_continuum=False)

--- a/trident/absorption_spectrum/absorption_spectrum.py
+++ b/trident/absorption_spectrum/absorption_spectrum.py
@@ -464,6 +464,13 @@ class AbsorptionSpectrum(object):
             input_ds = input_object.ds
             field_data = input_object
 
+        if self.bin_space == 'velocity':
+            if hasattr(input_ds, 'light_ray_solution'):
+                redshift = input_ds.light_ray_solution[-1].get('redshift', 0)
+            else:
+                redshift = 0
+            self.zero_redshift = redshift
+
         # temperature field required to calculate voigt profile widths
         if ('temperature' not in input_ds.derived_field_list) and \
            (('gas', 'temperature') not in input_ds.derived_field_list):
@@ -682,7 +689,13 @@ class AbsorptionSpectrum(object):
             return
 
         if self.bin_space == 'velocity':
-            wavelength_zero_point = self.line_list[0]['wavelength']
+            wavelength_zero_point = (1 + self.zero_redshift) * \
+              self.line_list[0]['wavelength']
+            mylog.info(
+                ('Setting wavelength of velocity center to %s ' +
+                 'line at z = %.3f: %s.') %
+                 (self.line_list[0]['label'], self.zero_redshift,
+                  wavelength_zero_point))
 
         # Change the redshifts of individual absorbers to account for the
         # redshift at which the observer sits

--- a/trident/absorption_spectrum/absorption_spectrum.py
+++ b/trident/absorption_spectrum/absorption_spectrum.py
@@ -465,11 +465,7 @@ class AbsorptionSpectrum(object):
             field_data = input_object
 
         if self.bin_space == 'velocity':
-            if hasattr(input_ds, 'light_ray_solution'):
-                redshift = input_ds.light_ray_solution[-1].get('redshift', 0)
-            else:
-                redshift = 0
-            self.zero_redshift = redshift
+            self.zero_redshift = getattr(input_ds, 'current_redshift', 0)
 
         # temperature field required to calculate voigt profile widths
         if ('temperature' not in input_ds.derived_field_list) and \


### PR DESCRIPTION
When making spectra in velocity space, this will set the wavelength of zero velocity according to the redshift from the light ray solution. This will prevent the velocities from having extremely large offsets when creating spectra from datasets at z > 0.

If it would be useful to have a user-settable parameter related to this, I'm open to it.

This will likely fail some velocity space tests. I'll regenerate answers after this is merged in that case.