### PR TITLE
Two circleci improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ commands:
     parameters:
       yttag:
         type: string
-        default: YT_HEAD
+        default: YT_GOLD
     steps:
       - run: |
           # add git user info so we can commit
@@ -42,30 +42,14 @@ commands:
               git clone --branch=yt-4.0 https://github.com/yt-project/yt $YT_DIR
           fi
           pushd $YT_DIR
-          git pull origin yt-4.0
+          # return to yt tip before pulling
+          git checkout ${YT_HEAD}
+          git pull origin ${YT_HEAD}
+          # checkout changeset we're actually testing
           git checkout ${<< parameters.yttag >>}
           pip install -e .
           popd
           pip install -e .[dev]
-
-  install-yt:
-    description: "Install yt."
-    parameters:
-      yttag:
-        type: string
-        default: YT_GOLD
-    steps:
-      - run: |
-          source $BASH_ENV
-          source $HOME/venv/bin/activate
-          if [ ! -f $YT_DIR/README.md ]; then
-              git clone --branch=yt-4.0 https://github.com/yt-project/yt $YT_DIR
-          fi
-          pushd $YT_DIR
-          git pull origin yt-4.0
-          git checkout ${<< parameters.yttag >>}
-          pip install -e .
-          popd
 
   install-trident:
     description: "Install trident."
@@ -206,9 +190,6 @@ jobs:
           paths:
             - ~/.trident
             - ~/answer_test_data
-
-      - install-yt:
-          yttag: << parameters.yttag >>
 
       - install-trident:
           tridenttag: "TRIDENT_GOLD"


### PR DESCRIPTION
1. Remove `install-yt` step as we already do that in `install-dependencies` and never change the yt version for a given test.
2. Change the default `yttag` from `YT_HEAD` to `YT_GOLD` so that the gold standard tests will always use the right yt version. This is not strictly necessary since the `tests` job already defaults to using `YT_GOLD`, just safer should we change anything.

Neither of these will change the results, but just simplify things a bit.

The `yt-tip` test will fail as that's currently failing due to changes in yt, but this can be merged anyway.