### PR TITLE
Sync circleci config with legacy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ commands:
           pip install Cython numpy
           if [ << parameters.yttag >> != "None" ]; then
               if [ ! -f $YT_DIR/README.md ]; then
-                  git clone --branch=yt-4.0 https://github.com/yt-project/yt $YT_DIR
+                  git clone --branch=${YT_HEAD} https://github.com/yt-project/yt $YT_DIR
               fi
               pushd $YT_DIR
               # return to yt tip before pulling

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -284,3 +284,22 @@ workflows:
        - docs-test:
            name: "Test docs build"
            tag: "3.8.1"
+
+   weekly:
+     triggers:
+       - schedule:
+           cron: "0 0 * * 1"
+           filters:
+            branches:
+              only:
+                - legacy
+     jobs:
+       - tests:
+           name: "Python 3.8 tests with yt tip"
+           tag: "3.8.1"
+           yttag: "YT_HEAD"
+           coverage: 0
+
+       - docs-test:
+           name: "Test docs build"
+           tag: "3.8.1"


### PR DESCRIPTION
This synchronizes the config files between `master` and `legacy` branches so the only things that are different will be the yt tip and gold standard tags.