### PR TITLE
[bugfix] allow access to find_outputs kwarg from make_compound_ray

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,14 +198,14 @@ jobs:
 
       - restore_cache:
           name: "Restore answer tests cache."
-          key: test-results-<< parameters.tag >>-<< parameters.yttag >>-v3
+          key: test-results-<< parameters.tag >>-<< parameters.yttag >>-v5
 
       - run-tests:
           generate: 1
 
       - save_cache:
           name: "Save answer tests cache."
-          key: test-results-<< parameters.tag >>-<< parameters.yttag >>-v3
+          key: test-results-<< parameters.tag >>-<< parameters.yttag >>-v5
           paths:
             - ~/answer_test_data/test_results
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,7 +166,7 @@ jobs:
 
       - restore_cache:
           name: "Restore dependencies cache."
-          key: python-<< parameters.tag >>-dependencies-v4
+          key: python-<< parameters.tag >>-dependencies-v5
 
       - install-dependencies:
           yttag: << parameters.yttag >>
@@ -174,7 +174,7 @@ jobs:
 
       - save_cache:
           name: "Save dependencies cache."
-          key: python-<< parameters.tag >>-dependencies-v4
+          key: python-<< parameters.tag >>-dependencies-v5
           paths:
             - ~/.cache/pip
             - ~/venv
@@ -198,14 +198,14 @@ jobs:
 
       - restore_cache:
           name: "Restore answer tests cache."
-          key: test-results-<< parameters.tag >>-<< parameters.yttag >>-v2
+          key: test-results-<< parameters.tag >>-<< parameters.yttag >>-v3
 
       - run-tests:
           generate: 1
 
       - save_cache:
           name: "Save answer tests cache."
-          key: test-results-<< parameters.tag >>-<< parameters.yttag >>-v2
+          key: test-results-<< parameters.tag >>-<< parameters.yttag >>-v3
           paths:
             - ~/answer_test_data/test_results
 

--- a/trident/ray_generator.py
+++ b/trident/ray_generator.py
@@ -234,12 +234,13 @@ def make_simple_ray(dataset_file, start_position, end_position,
                              redshift=redshift)
 
 def make_compound_ray(parameter_filename, simulation_type,
-                      near_redshift, far_redshift, find_outputs=False,
+                      near_redshift, far_redshift,
                       lines=None, ftype='gas', fields=None,
                       solution_filename=None, data_filename=None,
                       use_minimum_datasets=True, max_box_fraction=1.0,
                       deltaz_min=0.0, minimum_coherent_box_fraction=0.0,
-                      seed=None, setup_function=None, load_kwargs=None,
+                      find_outputs=False, seed=None,
+                      setup_function=None, load_kwargs=None,
                       line_database=None, ionization_table=None,
                       field_parameters = None):
     """
@@ -313,13 +314,6 @@ def make_compound_ray(parameter_filename, simulation_type,
         The near and far redshift bounds of the LightRay through the
         simulation datasets.
 
-    :find_outputs: optional, bool
-
-        Whether or not to search for datasets in the current
-        directory. This is useful if the number of existing datasets is
-        different than what would be predicted by the simulation parameter file.
-        Default: False.
-
     :lines: list of strings, optional
 
         List of strings that determine which fields will be added to the ray
@@ -389,6 +383,13 @@ def make_compound_ray(parameter_filename, simulation_type,
         the fraction of the total box width to be traversed before
         rerandomizing the ray location and trajectory.
         Default: 0.0
+
+    :find_outputs: optional, bool
+
+        Whether or not to search for datasets in the current
+        directory. This is useful if the number of existing datasets is
+        different than what would be predicted by the simulation parameter file.
+        Default: False.
 
     :seed: int, optional
 

--- a/trident/ray_generator.py
+++ b/trident/ray_generator.py
@@ -235,7 +235,7 @@ def make_simple_ray(dataset_file, start_position, end_position,
                              redshift=redshift)
 
 def make_compound_ray(parameter_filename, simulation_type,
-                      near_redshift, far_redshift,
+                      near_redshift, far_redshift, find_outputs=False,
                       lines=None, ftype='gas', fields=None,
                       solution_filename=None, data_filename=None,
                       use_minimum_datasets=True, max_box_fraction=1.0,
@@ -313,6 +313,13 @@ def make_compound_ray(parameter_filename, simulation_type,
 
         The near and far redshift bounds of the LightRay through the
         simulation datasets.
+
+    :find_outputs: optional, bool
+
+        Whether or not to search for datasets in the current
+        directory. This is useful if the number of existing datasets is
+        different than what would be predicted by the simulation parameter file.
+        Default: False.
 
     :lines: list of strings, optional
 
@@ -461,6 +468,7 @@ def make_compound_ray(parameter_filename, simulation_type,
                   simulation_type=simulation_type,
                   near_redshift=near_redshift,
                   far_redshift=far_redshift,
+                  find_outputs=find_outputs,
                   use_minimum_datasets=use_minimum_datasets,
                   max_box_fraction=max_box_fraction,
                   deltaz_min=deltaz_min,

--- a/trident/ray_generator.py
+++ b/trident/ray_generator.py
@@ -478,13 +478,12 @@ def make_compound_ray(parameter_filename, simulation_type,
     if ionization_table is None:
         ionization_table = ion_table_filepath
 
-    # We use the final dataset from the simulation in order to test it for
+    # We use the final dataset from the light ray solution in order to test it for
     # what fields are present, etc.  This all assumes that the fields present
     # in this output will be present in ALL outputs.  Hopefully this is true,
     # because testing each dataset is going to be slow and a pain.
 
-    sim = simulation(parameter_filename, simulation_type)
-    ds = load(sim.all_outputs[-1]['filename'])
+    ds = load(lr.light_ray_solution[-1]['filename'])
 
     # Include some default fields in the ray to assure it's processed correctly.
 

--- a/trident/ray_generator.py
+++ b/trident/ray_generator.py
@@ -14,8 +14,7 @@ SpectrumGenerator class and member functions.
 from trident.light_ray import \
     LightRay
 from yt.convenience import \
-    load, \
-    simulation
+    load
 from trident.config import \
     ion_table_filepath
 from trident.line_database import \


### PR DESCRIPTION
This fixes the problem associated with Issue #116. `make_compound_ray` attempts to load the last dataset on the dataset list to do field checking. However, if that dataset isn't present, we get an error. In the instance where not all data is present, the user would want to be able to pass the `find_outputs` keyword to the `LightRay` generator to only use outputs that are present. This PR allows one to do that.

I've also bumped the cache versions as a hail mary that it will fix the failing tests.