### PR TITLE
Rename legacy caches.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,7 +166,7 @@ jobs:
 
       - restore_cache:
           name: "Restore dependencies cache."
-          key: python-<< parameters.tag >>-dependencies-v2-legacy
+          key: legacy-<< parameters.tag >>-dependencies-v2
 
       - install-dependencies:
           yttag: << parameters.yttag >>
@@ -174,7 +174,7 @@ jobs:
 
       - save_cache:
           name: "Save dependencies cache."
-          key: python-<< parameters.tag >>-dependencies-v2-legacy
+          key: legacy-<< parameters.tag >>-dependencies-v2
           paths:
             - ~/.cache/pip
             - ~/venv
@@ -198,14 +198,14 @@ jobs:
 
       - restore_cache:
           name: "Restore answer tests cache."
-          key: test-results-<< parameters.tag >>-<< parameters.yttag >>-v3-legacy
+          key: legacy-results-<< parameters.tag >>-<< parameters.yttag >>-v3
 
       - run-tests:
           generate: 1
 
       - save_cache:
           name: "Save answer tests cache."
-          key: test-results-<< parameters.tag >>-<< parameters.yttag >>-v3-legacy
+          key: legacy-results-<< parameters.tag >>-<< parameters.yttag >>-v3
           paths:
             - ~/answer_test_data/test_results
 


### PR DESCRIPTION
I have reason to suspect that some of the recent test failures are due to similarity in the cache names between the `master` and `legacy` branches. On PR #117, I bumped the cache version so it would start fresh and it still found an existing cache, which it shouldn't have. For example, I think `test-answers-v3` matches to `test-answers-v3-legacy`.

This renames the legacy branch caches to different names from the start rather than the end of the string.