### PR TITLE
[bugfix] correct ray length for periodic rays

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ commands:
           echo 'TRIDENT_CONFIG=$HOME/.trident/config.tri' >> $BASH_ENV
           echo 'YT_GOLD=8dcc2fa135dfe7a62438507066527caf5cb379c1' >> $BASH_ENV
           echo 'YT_HEAD=yt-4.0' >> $BASH_ENV
-          echo 'TRIDENT_GOLD=test-standard-sph-viz-v5' >> $BASH_ENV
+          echo 'TRIDENT_GOLD=tip' >> $BASH_ENV
           echo 'TRIDENT_HEAD=tip' >> $BASH_ENV
 
   install-dependencies:
@@ -198,14 +198,14 @@ jobs:
 
       - restore_cache:
           name: "Restore answer tests cache."
-          key: test-results-<< parameters.tag >>-<< parameters.yttag >>-v5
+          key: test-results-<< parameters.tag >>-<< parameters.yttag >>-v6
 
       - run-tests:
           generate: 1
 
       - save_cache:
           name: "Save answer tests cache."
-          key: test-results-<< parameters.tag >>-<< parameters.yttag >>-v5
+          key: test-results-<< parameters.tag >>-<< parameters.yttag >>-v6
           paths:
             - ~/answer_test_data/test_results
 

--- a/tests/test_light_ray.py
+++ b/tests/test_light_ray.py
@@ -141,3 +141,13 @@ class LightRayTest(TempDirTest):
         ray = make_simple_ray(ds, start_position=ds.domain_left_edge, end_position=ds.domain_right_edge, lines=['H'])
         assert_almost_equal(ray.r['redshift'][0], 0.00489571, decimal=8)
         assert_almost_equal(ray.r['redshift'][-1], -0.00416831, decimal=8)
+
+    def test_light_ray_redshift_monotonic(self):
+        """
+        Tests to assure a light ray redshift decreases monotonically
+        when ray extends outside the domain.
+        """
+        ds = load(COSMO_PLUS_SINGLE)
+        ray = make_simple_ray(ds, start_position=ds.domain_center,
+                              end_position=ds.domain_center+ds.domain_width)
+        assert((np.diff(ray.data['redshift']) < 0).all())

--- a/trident/light_ray.py
+++ b/trident/light_ray.py
@@ -657,14 +657,14 @@ class LightRay(CosmologySplice):
                 sub_data[key] = ds.arr(sub_data[key]).in_cgs()
 
             # Calculate length along line of sight.
+            sub_data['dl'].convert_to_units('unitary')
             sub_data['l'] = sub_data['dl'].cumsum() - sub_data['dl']
 
             # Get redshift for each lixel.  Assume linear relation between l
             # and z.  so z = z_start - (l * (z_range / l_range))
             sub_data['redshift'] = my_segment['redshift'] - \
-              (sub_data['l'] * \
-              (my_segment['redshift'] - next_redshift) / \
-              vector_length(my_start, my_end).in_cgs())
+              (sub_data['l'] / sub_data['l'][-1]) * \
+              (my_segment['redshift'] - next_redshift)
 
             # When using the peculiar velocity, create effective redshift
             # (redshift_eff) field combining cosmological redshift and

--- a/trident/light_ray.py
+++ b/trident/light_ray.py
@@ -600,9 +600,6 @@ class LightRay(CosmologySplice):
                 for key, val in field_parameters.items():
                     sub_ray.set_field_parameter(key, val)
                 asort = np.argsort(sub_ray["t"])
-                sub_data['l'].extend(sub_ray['t'][asort] *
-                                     vector_length(sub_ray.start_point,
-                                                   sub_ray.end_point))
                 sub_data['dl'].extend(sub_ray['dts'][asort] *
                                       vector_length(sub_ray.start_point,
                                                     sub_ray.end_point))
@@ -658,6 +655,9 @@ class LightRay(CosmologySplice):
                 if key == "extra_data":
                     continue
                 sub_data[key] = ds.arr(sub_data[key]).in_cgs()
+
+            # Calculate length along line of sight.
+            sub_data['l'] = sub_data['dl'].cumsum() - sub_data['dl']
 
             # Get redshift for each lixel.  Assume linear relation between l
             # and z.  so z = z_start - (l * (z_range / l_range))

--- a/trident/light_ray.py
+++ b/trident/light_ray.py
@@ -35,7 +35,7 @@ from yt.utilities.physical_constants import speed_of_light_cgs
 from yt.data_objects.static_output import Dataset
 
 class LightRay(CosmologySplice):
-    """
+    r"""
     A 1D object representing the path of a light ray passing through a
     simulation.  LightRays can be either simple, where they pass through a
     single dataset, or compound, where they pass through consecutive

--- a/trident/light_ray.py
+++ b/trident/light_ray.py
@@ -668,9 +668,9 @@ class LightRay(CosmologySplice):
                 sub_data[key] = ds.arr(sub_data[key]).in_cgs()
 
             # Get redshift for each lixel.  Assume linear relation between l
-            # and z.  so z = z_start - (l * (z_range / l_range))
+            # and z.  so z = z_start - z_range * (l / l_range)
             sub_data['redshift'] = my_segment['redshift'] - \
-              (sub_data['l'] / sub_data['l'][-1]) * \
+              (sub_data['l'] / ray_length) * \
               (my_segment['redshift'] - next_redshift)
 
             # When using the peculiar velocity, create effective redshift


### PR DESCRIPTION
Periodic rays are composed of multiple non-periodic sub-segments. Previously, array lengths were calculated for each sub-segment individually, meaning each one started from 0. This resulted in the associated redshift jumping back to the starting redshift every time the ray left the box. ~~This fixes that issue by calculating the ray length as the cumulative sum of the 'dl' values along the line of sight after the sub-segment have been combined.~~

I previously fixed this in a way that only worked for grid data where the assumption that the `dl` values sum up to the total array length holds. I've now implemented a new fix where we accumulate the length along the ray using only the `l` values. This will work for both grids and particles and will give the same answers as the previous solution for the grid case.

I have verified that I get the same 'l' values for each individual sub-segment. I've also added a test for this.

Thanks to @Anikbh11 for identifying this issue!