### PR TITLE
[bugfix, legacy] fix periodic rays

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ commands:
           echo 'TRIDENT_CONFIG=$HOME/.trident/config.tri' >> $BASH_ENV
           echo 'YT_GOLD=6692802ea1bf7b4fbb6b0bc207aaea14730eec84' >> $BASH_ENV
           echo 'YT_HEAD=master' >> $BASH_ENV
-          echo 'TRIDENT_GOLD=test-standard-v5' >> $BASH_ENV
+          echo 'TRIDENT_GOLD=tip' >> $BASH_ENV
           echo 'TRIDENT_HEAD=tip' >> $BASH_ENV
 
   install-dependencies:
@@ -198,14 +198,14 @@ jobs:
 
       - restore_cache:
           name: "Restore answer tests cache."
-          key: legacy-results-<< parameters.tag >>-<< parameters.yttag >>-v3
+          key: legacy-results-<< parameters.tag >>-<< parameters.yttag >>-v4
 
       - run-tests:
           generate: 1
 
       - save_cache:
           name: "Save answer tests cache."
-          key: legacy-results-<< parameters.tag >>-<< parameters.yttag >>-v3
+          key: legacy-results-<< parameters.tag >>-<< parameters.yttag >>-v4
           paths:
             - ~/answer_test_data/test_results
 

--- a/tests/test_light_ray.py
+++ b/tests/test_light_ray.py
@@ -129,3 +129,23 @@ class LightRayTest(TempDirTest):
 
         ds = load('lightray.h5')
         compare_light_ray_solutions(lr, ds)
+
+    def test_light_ray_redshift_coverage(self):
+        """
+        Tests to assure a light ray covers the full redshift range appropriate
+        for that comoving line of sight distance.  Was not always so!
+        """
+        ds = load(GIZMO_COSMO_SINGLE)
+        ray = make_simple_ray(ds, start_position=ds.domain_left_edge, end_position=ds.domain_right_edge, lines=['H'])
+        assert_almost_equal(ray.r['redshift'][0], 0.00489571, decimal=8)
+        assert_almost_equal(ray.r['redshift'][-1], -0.00416831, decimal=8)
+
+    def test_light_ray_redshift_monotonic(self):
+        """
+        Tests to assure a light ray redshift decreases monotonically
+        when ray extends outside the domain.
+        """
+        ds = load(COSMO_PLUS_SINGLE)
+        ray = make_simple_ray(ds, start_position=ds.domain_center,
+                              end_position=ds.domain_center+ds.domain_width)
+        assert((np.diff(ray.data['redshift']) < 0).all())

--- a/tests/test_light_ray.py
+++ b/tests/test_light_ray.py
@@ -135,10 +135,10 @@ class LightRayTest(TempDirTest):
         Tests to assure a light ray covers the full redshift range appropriate
         for that comoving line of sight distance.  Was not always so!
         """
-        ds = load(GIZMO_COSMO_SINGLE)
+        ds = load(COSMO_PLUS_SINGLE)
         ray = make_simple_ray(ds, start_position=ds.domain_left_edge, end_position=ds.domain_right_edge, lines=['H'])
-        assert_almost_equal(ray.r['redshift'][0], 0.00489571, decimal=8)
-        assert_almost_equal(ray.r['redshift'][-1], -0.00416831, decimal=8)
+        assert_almost_equal(ray.r['redshift'][0], 0.00699901, decimal=8)
+        assert_almost_equal(ray.r['redshift'][-1], -0.01147344, decimal=8)
 
     def test_light_ray_redshift_monotonic(self):
         """

--- a/tests/test_light_ray.py
+++ b/tests/test_light_ray.py
@@ -130,16 +130,6 @@ class LightRayTest(TempDirTest):
         ds = load('lightray.h5')
         compare_light_ray_solutions(lr, ds)
 
-    def test_light_ray_redshift_coverage(self):
-        """
-        Tests to assure a light ray covers the full redshift range appropriate
-        for that comoving line of sight distance.  Was not always so!
-        """
-        ds = load(COSMO_PLUS_SINGLE)
-        ray = make_simple_ray(ds, start_position=ds.domain_left_edge, end_position=ds.domain_right_edge, lines=['H'])
-        assert_almost_equal(ray.r['redshift'][0], 0.00699901, decimal=8)
-        assert_almost_equal(ray.r['redshift'][-1], -0.01147344, decimal=8)
-
     def test_light_ray_redshift_monotonic(self):
         """
         Tests to assure a light ray redshift decreases monotonically

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -98,7 +98,7 @@ class PipelineTest(TempDirTest):
             old_spec = h5py.File(raw_file_compare, 'r')
             new_spec = h5py.File(raw_file, 'r')
             for key in old_spec.keys():
-                assert_almost_equal(new_spec[key].value, old_spec[key].value, \
+                assert_almost_equal(new_spec[key][()], old_spec[key][()], \
                                     decimal=err_precision,
                                     err_msg='Raw spectrum array does not match '+\
                                     'for enzo_small_simple answer test')
@@ -108,7 +108,7 @@ class PipelineTest(TempDirTest):
             old_spec = h5py.File(final_file_compare, 'r')
             new_spec = h5py.File(final_file, 'r')
             for key in old_spec.keys():
-                assert_almost_equal(new_spec[key].value, old_spec[key].value, \
+                assert_almost_equal(new_spec[key][()], old_spec[key][()], \
                                     decimal=err_precision,
                                     err_msg='Final spectrum array does not match '+\
                                     'for enzo_small_simple answer test')
@@ -170,7 +170,7 @@ class PipelineTest(TempDirTest):
             old_spec = h5py.File(raw_file_compare, 'r')
             new_spec = h5py.File(raw_file, 'r')
             for key in old_spec.keys():
-                assert_almost_equal(new_spec[key].value, old_spec[key].value, \
+                assert_almost_equal(new_spec[key][()], old_spec[key][()], \
                                     decimal=err_precision,
                                     err_msg='Raw spectrum array does not match '+\
                                     'for enzo_small_compound answer test')
@@ -180,7 +180,7 @@ class PipelineTest(TempDirTest):
             old_spec = h5py.File(final_file_compare, 'r')
             new_spec = h5py.File(final_file, 'r')
             for key in old_spec.keys():
-                assert_almost_equal(new_spec[key].value, old_spec[key].value, \
+                assert_almost_equal(new_spec[key][()], old_spec[key][()], \
                                     decimal=err_precision,
                                     err_msg='Final spectrum array does not match '+\
                                     'for enzo_small_compound answer test')
@@ -243,7 +243,7 @@ class PipelineTest(TempDirTest):
             old_spec = h5py.File(raw_file_compare, 'r')
             new_spec = h5py.File(raw_file, 'r')
             for key in old_spec.keys():
-                assert_almost_equal(new_spec[key].value, old_spec[key].value, \
+                assert_almost_equal(new_spec[key][()], old_spec[key][()], \
                                     decimal=err_precision,
                                     err_msg='Raw spectrum array does not match '+\
                                     'for gizmo_small_simple answer test')
@@ -253,7 +253,7 @@ class PipelineTest(TempDirTest):
             old_spec = h5py.File(final_file_compare, 'r')
             new_spec = h5py.File(final_file, 'r')
             for key in old_spec.keys():
-                assert_almost_equal(new_spec[key].value, old_spec[key].value, \
+                assert_almost_equal(new_spec[key][()], old_spec[key][()], \
                                     decimal=err_precision,
                                     err_msg='Final spectrum array does not match '+\
                                     'for gizmo_small_simple answer test')

--- a/trident/absorption_spectrum/absorption_spectrum.py
+++ b/trident/absorption_spectrum/absorption_spectrum.py
@@ -24,7 +24,6 @@ from yt.data_objects.data_containers import \
 from yt.data_objects.static_output import \
     Dataset
 from yt.convenience import load
-from yt.extern.six import string_types
 from yt.funcs import get_pbar, mylog
 from yt.units.yt_array import YTArray, YTQuantity
 from yt.utilities.on_demand_imports import _astropy
@@ -457,7 +456,7 @@ class AbsorptionSpectrum(object):
                 input_fields.append(feature['field_name'])
                 field_units[feature["field_name"]] = "cm**-3"
 
-        if isinstance(input_object, string_types):
+        if isinstance(input_object, str):
             input_ds = load(input_object)
             field_data = input_ds.all_data()
         elif isinstance(input_object, Dataset):

--- a/trident/config.py
+++ b/trident/config.py
@@ -12,10 +12,8 @@ Trident config
 #-----------------------------------------------------------------------------
 
 import os
-from six.moves.configparser import \
-    SafeConfigParser
-from six.moves import \
-    input
+from configparser import \
+    ConfigParser
 import shutil
 import tempfile
 import sys
@@ -108,7 +106,7 @@ def create_config():
     datafile = get_datafiles(datadir=datadir)
 
     # Create the config file and make it to the datadir and datafiles chosen
-    config = SafeConfigParser()
+    config = ConfigParser()
     config.add_section('Trident')
     config.set('Trident', 'ion_table_dir', datadir)
     config.set('Trident', 'ion_table_file', datafile)
@@ -152,13 +150,13 @@ def parse_config(variable=None):
     if os.path.exists(local_filename):
         config_filename = local_filename
     try:
-        parser = SafeConfigParser()
+        parser = ConfigParser()
         parser.read(config_filename)
         ion_table_dir = parser.get('Trident', 'ion_table_dir')
         ion_table_file = parser.get('Trident', 'ion_table_file')
     except BaseException:
         config_filename = create_config()
-        parser = SafeConfigParser()
+        parser = ConfigParser()
         parser.read(config_filename)
         ion_table_dir = parser.get('Trident', 'ion_table_dir')
         ion_table_file = parser.get('Trident', 'ion_table_file')

--- a/trident/ion_balance.py
+++ b/trident/ion_balance.py
@@ -16,7 +16,6 @@ from yt.fields.field_detector import \
 from yt.utilities.linear_interpolators import \
     TrilinearFieldInterpolator, \
     UnilinearFieldInterpolator
-import six
 from yt.utilities.physical_constants import mh
 from yt.funcs import mylog
 import numpy as np
@@ -306,7 +305,7 @@ def add_ion_fields(ds, ions, ftype='gas',
     # Otherwise, any ion can be selected (not just ones in the line list).
     else:
         if ions == 'all' or ions == ['all']:
-            for k, v in six.iteritems(atomic_number):
+            for k, v in atomic_number.items():
                 for j in range(v+1):
                     ion_list.append((k, j+1))
         else:

--- a/trident/light_ray.py
+++ b/trident/light_ray.py
@@ -657,12 +657,15 @@ class LightRay(CosmologySplice):
 
             # Calculate length along line of sight.
             sub_data['dl'].convert_to_units('unitary')
-            sub_data['l'] = sub_data['dl'].cumsum() - sub_data['dl']
+            # l_ray is ray length entering the cell
+            # sub_data['l'] is ray length leaving the cell
+            l_ray = sub_data['dl'].cumsum()
+            sub_data['l'] = l_ray - sub_data['dl']
 
             # Get redshift for each lixel.  Assume linear relation between l
             # and z.  so z = z_start - (l * (z_range / l_range))
             sub_data['redshift'] = my_segment['redshift'] - \
-              (sub_data['l'] / sub_data['l'][-1]) * \
+              (sub_data['l'] / l_ray[-1]) * \
               (my_segment['redshift'] - next_redshift)
 
             # When using the peculiar velocity, create effective redshift

--- a/trident/light_ray.py
+++ b/trident/light_ray.py
@@ -599,9 +599,6 @@ class LightRay(CosmologySplice):
                 for key, val in field_parameters.items():
                     sub_ray.set_field_parameter(key, val)
                 asort = np.argsort(sub_ray["t"])
-                sub_data['l'].extend(sub_ray['t'][asort] *
-                                     vector_length(sub_ray.start_point,
-                                                   sub_ray.end_point))
                 sub_data['dl'].extend(sub_ray['dts'][asort] *
                                       vector_length(sub_ray.start_point,
                                                     sub_ray.end_point))
@@ -657,6 +654,9 @@ class LightRay(CosmologySplice):
                 if key == "extra_data":
                     continue
                 sub_data[key] = ds.arr(sub_data[key]).in_cgs()
+
+            # Calculate length along line of sight.
+            sub_data['l'] = sub_data['dl'].cumsum() - sub_data['dl']
 
             # Get redshift for each lixel.  Assume linear relation between l
             # and z.  so z = z_start - (l * (z_range / l_range))

--- a/trident/light_ray.py
+++ b/trident/light_ray.py
@@ -656,14 +656,14 @@ class LightRay(CosmologySplice):
                 sub_data[key] = ds.arr(sub_data[key]).in_cgs()
 
             # Calculate length along line of sight.
+            sub_data['dl'].convert_to_units('unitary')
             sub_data['l'] = sub_data['dl'].cumsum() - sub_data['dl']
 
             # Get redshift for each lixel.  Assume linear relation between l
             # and z.  so z = z_start - (l * (z_range / l_range))
             sub_data['redshift'] = my_segment['redshift'] - \
-              (sub_data['l'] * \
-              (my_segment['redshift'] - next_redshift) / \
-              vector_length(my_start, my_end).in_cgs())
+              (sub_data['l'] / sub_data['l'][-1]) * \
+              (my_segment['redshift'] - next_redshift)
 
             # When using the peculiar velocity, create effective redshift
             # (redshift_eff) field combining cosmological redshift and

--- a/trident/light_ray.py
+++ b/trident/light_ray.py
@@ -35,7 +35,7 @@ from yt.utilities.physical_constants import speed_of_light_cgs
 from yt.data_objects.static_output import Dataset
 
 class LightRay(CosmologySplice):
-    """
+    r"""
     A 1D object representing the path of a light ray passing through a
     simulation.  LightRays can be either simple, where they pass through a
     single dataset, or compound, where they pass through consecutive

--- a/trident/line_database.py
+++ b/trident/line_database.py
@@ -19,9 +19,6 @@ from trident.config import \
 from trident.roman import \
     from_roman
 
-import six
-
-
 
 def uniquify(list):
     # order preserving method for reducing duplicates in a list
@@ -371,7 +368,7 @@ class LineDatabase:
             return self.lines_subset
         if subsets is None:
             subsets = []
-        if isinstance(subsets, six.string_types):
+        if isinstance(subsets, str):
             subsets = [subsets]
         for val in subsets:
             # try to add line based on identifier

--- a/trident/ray_generator.py
+++ b/trident/ray_generator.py
@@ -11,8 +11,6 @@ SpectrumGenerator class and member functions.
 # The full license is in the file LICENSE, distributed with this software.
 #-----------------------------------------------------------------------------
 
-import six
-
 from trident.light_ray import \
     LightRay
 from yt.convenience import \
@@ -610,7 +608,7 @@ def _determine_ions_from_lines(line_database, lines):
     else:
         ion_list = []
         if lines == 'all' or lines == ['all']:
-            for k,v in six.iteritems(atomic_number):
+            for k,v in atomic_number.items():
                 for j in range(v+1):
                     ion_list.append((k, j+1))
         else:

--- a/trident/utilities.py
+++ b/trident/utilities.py
@@ -15,14 +15,12 @@ import gzip
 import os
 from os.path import \
     expanduser
-import six
 import requests
 import tempfile
 import shutil
 from yt.funcs import \
     get_pbar
 import numpy as np
-from six.moves import input
 from yt.units import \
     cm, \
     pc, \
@@ -433,7 +431,7 @@ def make_onezone_ray(density=1e-26, temperature=1000, metallicity=0.3,
 
     # Add additional number_density fields to dataset
     if column_densities:
-        for k,v in six.iteritems(column_densities):
+        for k,v in column_densities.items():
             v = YTArray([v], 'cm**-2')
             data[k] = v/length
             field_types[k] = 'grid'


### PR DESCRIPTION
This is a reissue of PR #124 to the `legacy` branch. That PR to the `master` branch is held up while bugs in yt's ray selection for particle datasets in yt-4.0 is worked out.

This PR fixes an issue where the redshift of the ray is reset every time the ray crosses the domain boundary. This can be illustrated with the following code:
```
import numpy as np
import trident
import yt

ds = yt.load("DD0005/DD0005")

end = ds.domain_center
end[0] += ds.domain_width[0]
lr = trident.LightRay(ds)

lr.make_light_ray(start_position=ds.domain_center,
                 end_position=end)
print (np.diff(lr['redshift']))
```
which gives:
```
YTArray([-0.00200251, -0.00200251, -0.00200251, -0.00200251, -0.00200251,
         -0.00200251, -0.00200251, -0.00200251, -0.00200251, -0.00200251,
         -0.00200251, -0.00200251, -0.00200251, -0.00200251, -0.00200251,
          0.03003765, -0.00200251, -0.00200251, -0.00200251, -0.00200251,
         -0.00200251, -0.00200251, -0.00200251, -0.00200251, -0.00200251,
         -0.00200251, -0.00200251, -0.00200251, -0.00200251, -0.00200251,
         -0.00200251]) (dimensionless)
```
The positive value corresponds to when the redshift is reset to the starting redshift at the box edge. After this fix, this gives:
```
YTArray([-0.00206711, -0.00206711, -0.00206711, -0.00206711, -0.00206711,
         -0.00206711, -0.00206711, -0.00206711, -0.00206711, -0.00206711,
         -0.00206711, -0.00206711, -0.00206711, -0.00206711, -0.00206711,
         -0.00206711, -0.00206711, -0.00206711, -0.00206711, -0.00206711,
         -0.00206711, -0.00206711, -0.00206711, -0.00206711, -0.00206711,
         -0.00206711, -0.00206711, -0.00206711, -0.00206711, -0.00206711,
         -0.00206711]) (dimensionless)
```

Note, this fix won't work for the `master` branch because the `l` and `dl` fields have different meaning in yt-4.0. That said, I'd like to get this in here because it's a critical bug and people are using this.