### PR TITLE
Prepare legacy branch for parking

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -245,45 +245,14 @@ workflows:
            tag: "3.5.9"
 
        - tests:
-           name: "Python 3.6 tests with yt gold"
-           tag: "3.6.9"
-
-       - tests:
-           name: "Python 3.7 tests with yt gold"
-           tag: "3.7.6"
-
-       - tests:
            name: "Python 3.8 tests with yt gold"
-           tag: "3.8.1"
-
-       - tests:
-           name: "Python 3.8 tests with yt tip"
-           tag: "3.8.1"
+           tag: "3.8.2"
            yttag: "YT_GOLD"
            coverage: 1
 
        - docs-test:
            name: "Test docs build"
-           tag: "3.8.1"
-
-   daily:
-     triggers:
-       - schedule:
-           cron: "0 0 * * *"
-           filters:
-            branches:
-              only:
-                - master
-     jobs:
-       - tests:
-           name: "Python 3.8 tests with yt tip"
-           tag: "3.8.1"
-           yttag: "YT_GOLD"
-           coverage: 0
-
-       - docs-test:
-           name: "Test docs build"
-           tag: "3.8.1"
+           tag: "3.8.2"
 
    weekly:
      triggers:
@@ -295,11 +264,21 @@ workflows:
                 - legacy
      jobs:
        - tests:
-           name: "Python 3.8 tests with yt tip"
-           tag: "3.8.1"
-           yttag: "YT_GOLD"
-           coverage: 0
+           name: "Python 3.5 tests with yt gold"
+           tag: "3.5.9"
+
+       - tests:
+           name: "Python 3.6 tests with yt gold"
+           tag: "3.6.10"
+
+       - tests:
+           name: "Python 3.7 tests with yt gold"
+           tag: "3.7.7"
+
+       - tests:
+           name: "Python 3.8 tests with yt gold"
+           tag: "3.8.2"
 
        - docs-test:
            name: "Test docs build"
-           tag: "3.8.1"
+           tag: "3.8.2"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ commands:
           echo 'TRIDENT_ION_DATA=$HOME/.trident' >> $BASH_ENV
           echo 'TRIDENT_ANSWER_DATA=$HOME/answer_test_data' >> $BASH_ENV
           echo 'TRIDENT_CONFIG=$HOME/.trident/config.tri' >> $BASH_ENV
-          echo 'YT_GOLD=6692802ea1bf7b4fbb6b0bc207aaea14730eec84' >> $BASH_ENV
+          echo 'YT_GOLD=yt-3.6.0' >> $BASH_ENV
           echo 'YT_HEAD=master' >> $BASH_ENV
           echo 'TRIDENT_GOLD=test-standard-v6' >> $BASH_ENV
           echo 'TRIDENT_HEAD=tip' >> $BASH_ENV
@@ -45,7 +45,7 @@ commands:
               pushd $YT_DIR
               # return to yt tip before pulling
               git checkout ${YT_HEAD}
-              git pull origin ${YT_HEAD}
+              git pull origin ${YT_HEAD} --tag
               # checkout changeset we're actually testing
               git checkout ${<< parameters.yttag >>}
               pip install -e .
@@ -166,7 +166,7 @@ jobs:
 
       - restore_cache:
           name: "Restore dependencies cache."
-          key: legacy-<< parameters.tag >>-dependencies-v2
+          key: legacy-<< parameters.tag >>-dependencies-v3
 
       - install-dependencies:
           yttag: << parameters.yttag >>
@@ -174,7 +174,7 @@ jobs:
 
       - save_cache:
           name: "Save dependencies cache."
-          key: legacy-<< parameters.tag >>-dependencies-v2
+          key: legacy-<< parameters.tag >>-dependencies-v3
           paths:
             - ~/.cache/pip
             - ~/venv
@@ -198,14 +198,14 @@ jobs:
 
       - restore_cache:
           name: "Restore answer tests cache."
-          key: legacy-results-<< parameters.tag >>-<< parameters.yttag >>-v4
+          key: legacy-results-<< parameters.tag >>-<< parameters.yttag >>-v5
 
       - run-tests:
           generate: 1
 
       - save_cache:
           name: "Save answer tests cache."
-          key: legacy-results-<< parameters.tag >>-<< parameters.yttag >>-v4
+          key: legacy-results-<< parameters.tag >>-<< parameters.yttag >>-v5
           paths:
             - ~/answer_test_data/test_results
 
@@ -259,7 +259,7 @@ workflows:
        - tests:
            name: "Python 3.8 tests with yt tip"
            tag: "3.8.1"
-           yttag: "YT_HEAD"
+           yttag: "YT_GOLD"
            coverage: 1
 
        - docs-test:
@@ -278,7 +278,7 @@ workflows:
        - tests:
            name: "Python 3.8 tests with yt tip"
            tag: "3.8.1"
-           yttag: "YT_HEAD"
+           yttag: "YT_GOLD"
            coverage: 0
 
        - docs-test:
@@ -297,7 +297,7 @@ workflows:
        - tests:
            name: "Python 3.8 tests with yt tip"
            tag: "3.8.1"
-           yttag: "YT_HEAD"
+           yttag: "YT_GOLD"
            coverage: 0
 
        - docs-test:

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -12,7 +12,6 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-from __future__ import absolute_import
 import sys
 import os
 import shlex

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,6 @@ dependencies:
     - cycler==0.10.0
     - cython==0.29.13
     - decorator==4.4.0
-    - future==0.17.1
     - h5py==2.9.0
     - idna==2.8
     - ipython==7.7.0

--- a/environment.yml
+++ b/environment.yml
@@ -29,7 +29,6 @@ dependencies:
     - pyparsing==2.4.2
     - python-dateutil==2.8.0
     - requests==2.22.0
-    - six==1.12.0
     - sympy==1.4
     - traitlets==4.3.2
     - urllib3==1.25.3

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
         'matplotlib',
         'numpy!=1.14.0',
         'requests',
-        'yt>=3.4.0',
+        'yt>=3.6.0,<4.0',
         'yt_astro_analysis'],
       python_requires='>=3.5'
 )

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,6 @@ setup(
       },
     install_requires=[
         'astropy',
-        'future',
         'h5py',
         'matplotlib',
         'numpy!=1.14.0',

--- a/tests/gold_standard_versions.py
+++ b/tests/gold_standard_versions.py
@@ -11,12 +11,11 @@ Testing utilities for Trident
 # The full license is in the file LICENSE, distributed with this software.
 #-----------------------------------------------------------------------------
 
-from __future__ import print_function
 from trident import path as trident_path
 import os
 
 def get_gold_standard_version():
-    f = open(os.path.join(trident_path, '../.travis.yml'), 'r')
+    f = open(os.path.join(trident_path, '../.circleci/config.yml'), 'r')
     for line in f:
         line = line.lstrip()
         if line.startswith('YT_GOLD'):

--- a/tests/test_instrument.py
+++ b/tests/test_instrument.py
@@ -11,8 +11,6 @@ Tests for Instrument Class and Functions
 # The full license is in the file LICENSE, distributed with this software.
 #-----------------------------------------------------------------------------
 
-from __future__ import absolute_import
-from __future__ import print_function
 from trident.instrument import Instrument
 
 def test_instrument():

--- a/tests/test_ion_balance.py
+++ b/tests/test_ion_balance.py
@@ -11,7 +11,6 @@ Tests for ion balance code
 # The full license is in the file LICENSE, distributed with this software.
 #-----------------------------------------------------------------------------
 
-from __future__ import absolute_import
 from trident.ion_balance import \
     add_ion_fraction_field, \
     add_ion_number_density_field, \

--- a/tests/test_line_database.py
+++ b/tests/test_line_database.py
@@ -20,7 +20,6 @@ from trident.config import \
 import numpy as np
 from shutil import copyfile
 import os.path
-from six.moves import range
 
 def test_uniquify():
     """

--- a/tests/test_line_database.py
+++ b/tests/test_line_database.py
@@ -11,8 +11,6 @@ Tests for Line Database classes and functions
 # The full license is in the file LICENSE, distributed with this software.
 #-----------------------------------------------------------------------------
 
-from __future__ import absolute_import
-from __future__ import print_function
 from trident.line_database import \
     uniquify, \
     Line, \

--- a/tests/test_lsf.py
+++ b/tests/test_lsf.py
@@ -11,8 +11,6 @@ Tests for Line Spread Function class and functions
 # The full license is in the file LICENSE, distributed with this software.
 #-----------------------------------------------------------------------------
 
-from __future__ import absolute_import
-from __future__ import print_function
 import pytest
 from trident.lsf import LSF
 import numpy as np

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -11,7 +11,6 @@ Tests for Plotting functionality
 # The full license is in the file LICENSE, distributed with this software.
 #-----------------------------------------------------------------------------
 
-from __future__ import absolute_import
 from trident.plotting import plot_spectrum
 from trident.utilities import make_onezone_ray
 from trident.spectrum_generator import \

--- a/tests/test_ray_generator.py
+++ b/tests/test_ray_generator.py
@@ -11,7 +11,6 @@ Tests for ion balance code
 # The full license is in the file LICENSE, distributed with this software.
 #-----------------------------------------------------------------------------
 
-from __future__ import absolute_import
 import trident as tri
 import tempfile
 import shutil

--- a/tests/test_spectrum_generator.py
+++ b/tests/test_spectrum_generator.py
@@ -11,7 +11,6 @@ Tests for Spectrum Generation
 # The full license is in the file LICENSE, distributed with this software.
 #-----------------------------------------------------------------------------
 
-from __future__ import absolute_import
 from trident.plotting import plot_spectrum
 from trident.utilities import make_onezone_ray
 from trident.spectrum_generator import \

--- a/trident/absorption_spectrum/absorption_spectrum.py
+++ b/trident/absorption_spectrum/absorption_spectrum.py
@@ -5,8 +5,6 @@ AbsorptionSpectrum class and member functions.
 
 """
 
-from __future__ import absolute_import
-
 #-----------------------------------------------------------------------------
 # Copyright (c) 2013-2017, yt Development Team.
 # Copyright (c) 2017, Trident Development Team.


### PR DESCRIPTION
The recent yt-3.6 release was the last of the 3.x series, so there is no longer any point for the legacy branch to continue to test with the yt `master` branch. Soon, that will be exclusively for yt-4.0 development and will not work with Trident's `legacy` branch. This PR decouples Trident `legacy` branch testing from yt `master` and instead tests exclusively on the yt-3.6.0 release. I've also made the following changes/updates:

1. update to most recent Python versions for testing
2. remove Python 2 `__future__` module imports
3. move intermediate Python versions to weekly testing and only test PRs with oldest and newest versions
4. update caches since I changed the gold standard to yt-3.6.0
5. remove testing entries for Trident `master` branch. It was unnecessary of me to include those in this branch.