### PR TITLE
Fixing bug preventing Trident from running on Windows

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,34 @@
+"""
+Tests for Config Code
+
+"""
+
+#-----------------------------------------------------------------------------
+# Copyright (c) 2016, Trident Development Team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+#-----------------------------------------------------------------------------
+
+from trident.config import \
+    trident, \
+    trident_path, \
+    create_config, \
+    parse_config
+
+def test_banner():
+    """
+    Tests running the banner display
+    """
+    trident()
+
+def test_path():
+    """
+    Tests that the trident path is working ok.
+    """
+    trident_path()
+
+# Need to make a test_config but this necessitates changing the config
+# code around a bunch.
+

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1,0 +1,59 @@
+"""
+Tests for Utilities Code
+
+"""
+
+#-----------------------------------------------------------------------------
+# Copyright (c) 2016, Trident Development Team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+#-----------------------------------------------------------------------------
+
+import os
+import tempfile
+import filecmp
+from trident.utilities import \
+    ensure_directory, \
+    gunzip_file, \
+    gzip_file, \
+    make_onezone_dataset, \
+    make_onezone_ray
+
+def test_ensure_directory():
+    """
+    Tests ensure_directory code, which ensures a path exists and if not, 
+    it creates such a path
+    """
+    tempdir = tempfile.mkdtemp()
+    ensure_directory(tempdir)
+    assert os.path.exists(tempdir)
+
+    # is new random path created?
+    subdir = os.path.join(tempdir, 'random')
+    assert not os.path.exists(subdir)
+    ensure_directory(subdir)
+    assert os.path.exists(subdir)
+
+def test_gzip_unzip_file():
+    # Create a temporary directory
+    tmpdir = tempfile.mkdtemp()
+
+    # Create a temporary file
+    fp = tempfile.NamedTemporaryFile()
+    fp.write(b'Hello world!')
+    filepath = fp.name
+    directory, filename = os.path.split(filepath)
+    gzip_filename = os.path.join(tmpdir, filename+'.gz')
+    gunzip_filename = os.path.join(tmpdir, filename)
+
+    # Gzip it
+    gzip_file(filepath, out_filename=gzip_filename, cleanup=False)
+
+    # Gunzip it
+    gunzip_file(gzip_filename, out_filename=gunzip_filename, cleanup=False)
+
+    # Ensure contents of gunzipped file are the same as original
+    filecmp.cmp(filepath, gunzip_filename)
+

--- a/trident/config.py
+++ b/trident/config.py
@@ -64,7 +64,7 @@ def create_config():
     datafile from the web.  It does this using user interaction from the
     python prompt.
     """
-    default_dir = os.path.expanduser('~/.trident')
+    default_dir = os.path.expanduser(os.path.join('~', '.trident'))
     trident()
     print("It appears that this is your first time using Trident.  To finalize your")
     print("Trident installation, you must:")
@@ -110,7 +110,7 @@ def create_config():
     config.add_section('Trident')
     config.set('Trident', 'ion_table_dir', datadir)
     config.set('Trident', 'ion_table_file', datafile)
-    config_filename = os.path.expanduser('~/.trident/config.tri')
+    config_filename = os.path.expanduser(os.path.join('~', '.trident', 'config.tri'))
     with open(config_filename, 'w') as configfile:
         config.write(configfile)
 

--- a/trident/config.py
+++ b/trident/config.py
@@ -13,7 +13,8 @@ Trident config
 
 import os
 from configparser import \
-    ConfigParser
+    ConfigParser, \
+    NoSectionError
 import shutil
 import tempfile
 import sys
@@ -154,7 +155,7 @@ def parse_config(variable=None):
         parser.read(config_filename)
         ion_table_dir = parser.get('Trident', 'ion_table_dir')
         ion_table_file = parser.get('Trident', 'ion_table_file')
-    except BaseException:
+    except NoSectionError:
         config_filename = create_config()
         parser = ConfigParser()
         parser.read(config_filename)

--- a/trident/utilities.py
+++ b/trident/utilities.py
@@ -86,7 +86,7 @@ def download_file(url, progress_bar=True, local_directory=None,
 
     # Set defaults
     if local_filename is None:
-        local_filename = url.split(os.sep)[-1]
+        local_filename = url.split('/')[-1]
     if local_directory is None:
         local_directory = '.'
     ensure_directory(local_directory)

--- a/trident/utilities.py
+++ b/trident/utilities.py
@@ -13,8 +13,6 @@ Miscellaneous Utilities for Trident
 
 import gzip
 import os
-from os.path import \
-    expanduser
 import requests
 import tempfile
 import shutil
@@ -210,7 +208,7 @@ def get_datafiles(datadir=None, url=None):
     >>> get_datafiles()
     """
     if datadir is None:
-        datadir = expanduser(os.path.join('~','.trident'))
+        datadir = os.path.expanduser(os.path.join('~','.trident'))
     ensure_directory(datadir)
 
     # ion table datafiles are stored here

--- a/trident/utilities.py
+++ b/trident/utilities.py
@@ -210,7 +210,7 @@ def get_datafiles(datadir=None, url=None):
     >>> get_datafiles()
     """
     if datadir is None:
-        datadir = expanduser('~/.trident')
+        datadir = expanduser(os.path.join('~','.trident'))
     ensure_directory(datadir)
 
     # ion table datafiles are stored here

--- a/trident/utilities.py
+++ b/trident/utilities.py
@@ -86,7 +86,7 @@ def download_file(url, progress_bar=True, local_directory=None,
 
     # Set defaults
     if local_filename is None:
-        local_filename = url.split('/')[-1]
+        local_filename = os.path.basename(url)
     if local_directory is None:
         local_directory = '.'
     ensure_directory(local_directory)


### PR DESCRIPTION
This error was reported by user David Abramov.  Trident was failing to install on a windows machine during the auto-download portion where the user acquires the ion_balance datafiles.  I found some places where I had previously disregarded the `os.path` conventions and hard-coded a '/' for the file separator.

Note, I have also used this as an excuse to add some tests to utilities and config functionality to enhance our test coverage.