### PR TITLE
Removes blocking behavior when trident is not configured

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,11 +1,11 @@
 Trident Documentation
 =====================
 
-Trident is a Python package for creating synthetic absorption-line spectra 
-from astrophysical hydrodynamics simulations.  It utilizes the yt package
-to read in simulation datasets and extends it to provide realistic 
-synthetic observations appropriate for studies of the interstellar,
-circumgalactic, and intergalactic media.
+Trident is a Python package for calculating ion populations and creating
+synthetic absorption-line spectra from astrophysical hydrodynamics simulations.
+It utilizes the yt package to read in simulation datasets and extends it to
+provide realistic synthetic observations appropriate for studies of the
+interstellar, circumgalactic, and intergalactic media.
 
 To avoid confusion, make sure you are viewing the correct documentation for 
 the version of Trident you are using: 

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -18,26 +18,19 @@ The stable version is tried and tested, and it normally operates on a stable
 version of yt.  The development version is actively being updated with new
 features, and it is also tied to the development version of yt, so occasionally
 unforseen bugs can crop up as these new features are added.  The demeshening
-version is currently in beta and active development and is used for better
-results on particle-based datasets.
+version is an ongoing effort to treat particle-based datasets natively, which
+has been merged into the development version of Trident.  Now, there are only
+the stable and development versions.
 
-After Trident 1.2 was released on September 19, 2019, the demeshening version
-was merged with the main development branch. Now, there are only the stable
-version and the development version. 
+If you are dealing with an SPH or Voronoi Tesselation code like Gadget, Gizmo,
+AREPO, Gasoline, or Changa, you will get best and fastest results from using the
+development version of Trident and yt.
 
-The installation steps are slightly different between the two versions,
-so pay attention in the steps below.  Don't worry if you want to change later,
-you can always switch between the two versions easily enough by following the
-directions in :ref:`uninstallation`.
-
-.. note::
-    The demeshening (development) version treats particle-based
-    datasets more natively.  The demeshening version will give faster and more 
-    accurate results with less memory overhead for particle-based datasets.  
-    For more information about the demeshening version, please see our
-    `demeshening notebook
-    <https://nbviewer.jupyter.org/url/trident-project.org/notebooks/trident_demesh_install.ipynb>`_. **Note, the installation instructions in the notebook should be ignored.**
-    Instead, follow the instructions for :ref:`install-dev`.
+The installation steps are slightly different between the two versions, in that
+the stable version of Trident requires a stable release of yt, whereas
+the development version of Trident requires the development version of yt.
+Don't worry if you want to change later, you can always switch between the two
+versions easily enough by following the directions in :ref:`uninstallation`.
 
 .. _step-1:
 

--- a/trident/__init__.py
+++ b/trident/__init__.py
@@ -24,7 +24,7 @@ import_check()
 
 from trident.config import \
     parse_config, \
-    create_config, \
+    configure, \
     trident, \
     trident_path, \
     verify

--- a/trident/__init__.py
+++ b/trident/__init__.py
@@ -19,7 +19,7 @@ __version__ = "1.3.dev1"
 
 from trident.config import \
     parse_config, \
-    configure, \
+    auto_config, \
     trident, \
     trident_path, \
     verify

--- a/trident/__init__.py
+++ b/trident/__init__.py
@@ -68,3 +68,6 @@ from trident.light_ray import \
 
 # Making installation path global
 path = trident_path()
+
+# Check that configuration is correct
+parse_config(first_parse=True)

--- a/trident/__init__.py
+++ b/trident/__init__.py
@@ -17,11 +17,6 @@ http://yt-project.org
 
 __version__ = "1.3.dev1"
 
-# Must run import_check() before anything else is imported to avoid
-# astropy error when importing trident in trident package directory
-from trident.utilities import import_check
-import_check()
-
 from trident.config import \
     parse_config, \
     configure, \

--- a/trident/config.py
+++ b/trident/config.py
@@ -57,7 +57,7 @@ def trident_path():
     # Here, __file__ refers to this file (config.py)
     return os.path.split(__file__)[0]
 
-def configure():
+def auto_config():
     """
     Create a Trident configuration file using interaction with the user.
     If it appears that the configuration has not yet been set up for the user,
@@ -123,10 +123,10 @@ def config_error(verbose=False):
         print("do it automatically now if you have web access.  Most functionality")
         print("will fail until you accomplish this configuration step.")
         print("")
-        print("To proceed automatically, please run: trident.configure()")
+        print("To proceed automatically, please run: trident.auto_config()")
     else:
         mylog.error("SOMETHING IS WRONG WITH YOUR CONFIGURATION AND ION_BALANCE FILE.")
-        mylog.error("MOST FUNCTIONALITY WILL FAIL UNTIL YOU RUN: trident.configure()")
+        mylog.error("MOST FUNCTIONALITY WILL FAIL UNTIL YOU RUN: trident.auto_config()")
     return
  
 def parse_config(variable=None, first_parse=False):
@@ -136,7 +136,7 @@ def parse_config(variable=None, first_parse=False):
     the default ion table datafiles exist.  If a ``config.tri`` file doesn't
     exist in ``$HOME/.trident`` or in the current working directory, then
     Trident will launch the request the user run the
-    :class:`~trident.configure` function to automatically generate one for the
+    :class:`~trident.auto_config` function to automatically generate one for the
     user.  For more information on this process, see the installation 
     documentation.
 

--- a/trident/config.py
+++ b/trident/config.py
@@ -17,6 +17,8 @@ from configparser import \
 import shutil
 import tempfile
 import sys
+from yt.funcs import \
+    mylog
 
 from trident.utilities import \
     ensure_directory, \
@@ -123,10 +125,8 @@ def config_error(verbose=False):
         print("")
         print("To proceed automatically, please run: trident.configure()")
     else:
-        print("")
-        print("Something is wrong with your configuration and ion_balance file.")
-        print("Most functionality will fail until you run: trident.configure()")
-        print("")
+        mylog.error("SOMETHING IS WRONG WITH YOUR CONFIGURATION AND ION_BALANCE FILE.")
+        mylog.error("MOST FUNCTIONALITY WILL FAIL UNTIL YOU RUN: trident.configure()")
     return
  
 def parse_config(variable=None, first_parse=False):
@@ -173,10 +173,8 @@ def parse_config(variable=None, first_parse=False):
         ion_table_dir = os.path.abspath(os.path.expanduser(ion_table_dir))
         ion_table_filepath = os.path.join(ion_table_dir, ion_table_file)
         if not os.path.exists(ion_table_filepath):
-            print("")
-            print("No ion table data file found in %s" % ion_table_dir)
-            print("Most functionality will fail until you fix this problem.")
-            print("")
+            mylog.error("NO ION TABLE DATA FILE FOUND IN %s" % ion_table_dir)
+            mylog.error("MOST FUNCTIONALITY WILL FAIL UNTIL YOU FIX THIS PROBLEM.")
     except BaseException:
        config_error(verbose=first_parse) 
        return

--- a/trident/config.py
+++ b/trident/config.py
@@ -68,7 +68,7 @@ def configure():
     print("Where would you like Trident to store the ion table file?")
     print("[%s]" % default_dir)
 
-    # First assure that the .trident directory is created for storing
+    # First ensure that the .trident directory is created for storing
     # the config file.
     ensure_directory(default_dir)
 
@@ -100,12 +100,36 @@ def configure():
 
     print("")
     print("Installation complete.  I recommend verifying your installation")
-    print("to assure that everything is working.  Try: trident.verify()")
+    print("to ensure that everything is working.  Try: trident.verify()")
 
     # Return the config file path so we can load it and get parameters.
     return config_filename
 
-def parse_config(variable=None):
+def config_error(verbose=False):
+    """
+    Print an error to STDOUT about the configuration being incorrect.
+    """
+    if verbose:
+        trident()
+        print("It appears that this is your first time using Trident.  To finalize your")
+        print("Trident installation, you must:")
+        print(" * create a `~/.trident` directory")
+        print(" * create a config.tri file in your `~/.trident` directory")
+        print(" * download an ion table file for calculating ionization fractions")
+        print("")
+        print("You can do this manually by following the installation docs, or we can")
+        print("do it automatically now if you have web access.  Most functionality")
+        print("will fail until you accomplish this configuration step.")
+        print("")
+        print("To proceed automatically, please run: trident.configure()")
+    else:
+        print("")
+        print("Something is wrong with your configuration and ion_balance file.")
+        print("Most functionality will fail until you run: trident.configure()")
+        print("")
+    return
+ 
+def parse_config(variable=None, first_parse=False):
     """
     Parse the Trident local configuration file.  This function is called
     whenever Trident is imported, and it ensure that Trident knows where
@@ -124,8 +148,14 @@ def parse_config(variable=None):
         file, specify that variable name here.  Will return the result
         value of that variable. If None set, returns ion balance filepath.
         Default: None
+
+    :first_parse: boolean, optional
+        
+        If this is the first time parsing the configuration and it isn't
+        correct, then give a verbose error message.
+        Default: False
     """
-    # Assure the ~/.trident directory exists, and read in the config file.
+    # Ensure the ~/.trident directory exists, and read in the config file.
     home = os.path.expanduser("~")
     directory = os.path.join(home, '.trident')
     config_filename = os.path.join(directory, 'config.tri')
@@ -145,21 +175,11 @@ def parse_config(variable=None):
         if not os.path.exists(ion_table_filepath):
             print("")
             print("No ion table data file found in %s" % ion_table_dir)
+            print("Most functionality will fail until you fix this problem.")
             print("")
     except BaseException:
-        trident()
-        print("It appears that this is your first time using Trident.  To finalize your")
-        print("Trident installation, you must:")
-        print(" * create a `~/.trident` directory")
-        print(" * create a config.tri file in your `~/.trident` directory")
-        print(" * download an ion table file for calculating ionization fractions")
-        print("")
-        print("You can do this manually by following the installation docs, or we can")
-        print("do it automatically now if you have web access.  Most functionality")
-        print("will fail until you accomplish this configuration step.")
-        print("")
-        print("To proceed automatically, please run: trident.configure()")
-        return
+       config_error(verbose=first_parse) 
+       return
 
     # value to return depends on what was set for "variable"
     if variable is None:

--- a/trident/config.py
+++ b/trident/config.py
@@ -251,17 +251,3 @@ def verify(save=False):
     print("Congratulations, you have verified that Trident is installed correctly.")
     print("Now let's science!")
     print("")
-
-# Each time Trident is imported, we determine the settings from the config
-# file or try to create a config file.  But don't do this on readthedocs, or
-# it will fail in the build. In readthedocs environment, just set a dummy
-# filepath so readthedocs can parse the docstrings OK.
-
-
-on_rtd = os.environ.get('READTHEDOCS') == 'True'
-if on_rtd:
-    ion_table_dir = trident_path()
-    ion_table_file = '__init__.py'
-    ion_table_filepath = os.path.join(ion_table_dir, ion_table_file)
-else:
-    ion_table_filepath = parse_config()

--- a/trident/ion_balance.py
+++ b/trident/ion_balance.py
@@ -23,7 +23,7 @@ import h5py
 import copy
 import os
 from trident.config import \
-    ion_table_filepath
+    parse_config
 from trident.line_database import \
     LineDatabase, \
     uniquify
@@ -65,7 +65,7 @@ class IonBalanceTable(object):
             Default: None
         """
         if filename is None:
-            filename = ion_table_filepath
+            filename = parse_config()
         self.filename = filename
         self.parameters = []
         self.ion_fraction = []
@@ -194,7 +194,7 @@ def add_ion_fields(ds, ions, ftype='gas',
         Path to an appropriately formatted HDF5 table that can be used to
         compute the ion fraction as a function of density, temperature,
         metallicity, and redshift.  When set to None, it uses the table
-        specified in ~/.trident/config
+        specified in ~/.trident/config.tri
         Default: None
 
     :field_suffix: boolean, optional
@@ -238,7 +238,7 @@ def add_ion_fields(ds, ions, ftype='gas',
     ion_list = []
 
     if ionization_table is None:
-        ionization_table = ion_table_filepath
+        ionization_table = parse_config()
 
     # Parse the ions given following the LineDatabase syntax
 
@@ -320,7 +320,7 @@ def add_ion_fraction_field(atom, ion, ds, ftype="gas",
         Path to an appropriately formatted HDF5 table that can be used to
         compute the ion fraction as a function of density, temperature,
         metallicity, and redshift.  By default, it uses the table specified in
-        ~/.trident/config
+        ~/.trident/config.tri
 
     :field_suffix: boolean, optional
         Determines whether or not to append a suffix to the field name that
@@ -348,7 +348,7 @@ def add_ion_fraction_field(atom, ion, ds, ftype="gas",
     """
 
     if ionization_table is None:
-        ionization_table = ion_table_filepath
+        ionization_table = parse_config()
 
     if ("gas", "log_nH") not in ds.derived_field_list:
         _add_field(ds, ("gas", "log_nH"), function=_log_nH, units="",
@@ -439,7 +439,7 @@ def add_ion_number_density_field(atom, ion, ds, ftype="gas",
         Path to an appropriately formatted HDF5 table that can be used to
         compute the ion fraction as a function of density, temperature,
         metallicity, and redshift.  By default, it uses the table specified in
-        ~/.trident/config
+        ~/.trident/config.tri
 
     :field_suffix: boolean, optional
 
@@ -468,7 +468,8 @@ def add_ion_number_density_field(atom, ion, ds, ftype="gas",
     """
 
     if ionization_table is None:
-        ionization_table = ion_table_filepath
+        ionization_table = parse_config()
+
     atom = atom.capitalize()
     # if neutral ion field, alias X_number_density to X_p0_number_density field
     field = "%s_p%d_number_density" % (atom, ion-1)
@@ -536,7 +537,7 @@ def add_ion_density_field(atom, ion, ds, ftype="gas",
         Path to an appropriately formatted HDF5 table that can be used to
         compute the ion fraction as a function of density, temperature,
         metallicity, and redshift.  By default, it uses the table specified in
-        ~/.trident/config
+        ~/.trident/config.tri
 
     :field_suffix: boolean, optional
 
@@ -565,7 +566,8 @@ def add_ion_density_field(atom, ion, ds, ftype="gas",
     """
 
     if ionization_table is None:
-        ionization_table = ion_table_filepath
+        ionization_table = parse_config()
+
     atom = atom.capitalize()
 
     # if neutral ion field, alias X_number_density to X_p0_number_density field
@@ -634,7 +636,7 @@ def add_ion_mass_field(atom, ion, ds, ftype="gas",
         Path to an appropriately formatted HDF5 table that can be used to
         compute the ion fraction as a function of density, temperature,
         metallicity, and redshift.  By default, it uses the table specified in
-        ~/.trident/config
+        ~/.trident/config.tri
 
     :field_suffix: boolean, optional
 
@@ -663,7 +665,8 @@ def add_ion_mass_field(atom, ion, ds, ftype="gas",
     """
 
     if ionization_table is None:
-        ionization_table = ion_table_filepath
+        ionization_table = parse_config()
+
     atom = atom.capitalize()
 
     # if neutral ion field, alias X_number_density to X_p0_number_density field

--- a/trident/ray_generator.py
+++ b/trident/ray_generator.py
@@ -16,7 +16,7 @@ from trident.light_ray import \
 from yt.convenience import \
     load
 from trident.config import \
-    ion_table_filepath
+    parse_config
 from trident.line_database import \
     LineDatabase, \
     uniquify
@@ -166,7 +166,7 @@ def make_simple_ray(dataset_file, start_position, end_position,
         For use with the :lines: keyword.  Path to an appropriately formatted
         HDF5 table that can be used to compute the ion fraction as a function
         of density, temperature, metallicity, and redshift.  When set to None,
-        it uses the table specified in ~/.trident/config
+        it uses the table specified in ~/.trident/config.tri
         Default: None
 
     **Example**
@@ -196,7 +196,7 @@ def make_simple_ray(dataset_file, start_position, end_position,
     lr = LightRay(ds, load_kwargs=load_kwargs)
 
     if ionization_table is None:
-        ionization_table = ion_table_filepath
+        ionization_table = parse_config()
 
     # Include some default fields in the ray to assure it's processed correctly.
 
@@ -429,7 +429,7 @@ def make_compound_ray(parameter_filename, simulation_type,
         For use with the :lines: keyword.  Path to an appropriately formatted
         HDF5 table that can be used to compute the ion fraction as a function
         of density, temperature, metallicity, and redshift.  When set to None,
-        it uses the table specified in ~/.trident/config
+        it uses the table specified in ~/.trident/config.tri
         Default: None
 
     :field_parameters: optional, dict
@@ -476,7 +476,7 @@ def make_compound_ray(parameter_filename, simulation_type,
                   load_kwargs=load_kwargs)
 
     if ionization_table is None:
-        ionization_table = ion_table_filepath
+        ionization_table = parse_config()
 
     # We use the final dataset from the light ray solution in order to test it for
     # what fields are present, etc.  This all assumes that the fields present

--- a/trident/spectrum_generator.py
+++ b/trident/spectrum_generator.py
@@ -27,9 +27,8 @@ from yt.funcs import \
     YTArray
 
 from trident.config import \
-    ion_table_dir, \
-    ion_table_file, \
-    ion_table_filepath
+    parse_config, \
+    trident_path
 from trident.instrument import \
     Instrument
 from trident.ion_balance import \
@@ -41,8 +40,6 @@ from trident.lsf import \
     LSF
 from trident.plotting import \
     plot_spectrum
-from trident.config import \
-    trident_path
 from yt.utilities.on_demand_imports import \
     _h5py, \
     _astropy
@@ -227,15 +224,19 @@ class SpectrumGenerator(AbsorptionSpectrum):
 
         if ionization_table is not None:
             # figure out where the user-specified files lives
-            if os.path.isfile(ion_table_file):
-                self.ionization_table = ion_table_file
-            elif os.path.isfile(ion_table_filepath):
-                self.ionization_table = ion_table_filepath
+            local_filepath = os.path.join(os.getcwd(), ionization_table)
+            config_dir = parse_config('ion_table_dir')
+            config_dir_filepath = os.path.join(config_dir, ionization_table)
+            if os.path.isfile(local_filepath):
+                self.ionization_table = local_filepath
+            elif os.path.isfile(config_dir_filepath):
+                self.ionization_table = config_dir_filepath
             else:
                 raise RuntimeError("ionization_table %s is not found in local "
                                    "directory or in %s" %
-                                   (ion_table_file.split(os.sep)[-1],
-                                    ion_table_dir))
+                                   (ionization_table, config_dir))
+
+            mylog.info("Using ionization table %s" % self.ionization_table)
         else:
             self.ionization_table = None
 

--- a/trident/utilities.py
+++ b/trident/utilities.py
@@ -450,16 +450,3 @@ def make_onezone_ray(density=1e-26, temperature=1000, metallicity=0.3,
     ray.domain_right_edge = ray.domain_right_edge.to('code_length')
 
     return ray
-
-def import_check():
-    """
-    """
-    # Avoid astropy error when importing from trident package directory.
-    plist = os.path.dirname(os.path.abspath(__file__)).split(os.sep)
-    package_path = os.sep.join(plist[:-1])
-    if os.getcwd() == package_path:
-        raise RuntimeError(
-            """
-
-The Trident package does not work correctly when imported from its
-installation directory.  Please try moving to another directory.""")


### PR DESCRIPTION
This PR addresses Issue #57 and makes it so that Trident can operate minimally even when it hasn't been configured.  Prior to this, Trident would block and require user input in order to proceed, which meant that it didn't play well with other codes as a dependency or with automatic documentation generation with Readthedocs.  

This PR removes that blocking behavior.  When initially imported, trident prints a verbose message to the user requesting that they run a command to automatically generate the config file and download the ion_balance file.  Furthermore, if this is ignored, Trident tries to operate without this information.  If specific functions *require* ion balance information, it prints an error message and continues, but will fail.

This started out as a PR to update the installation documentation, but I figured this blocking behavior should be addressed first, and then the rest of the install docs can be updated.