### PR TITLE
yt-4.0 testing updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ commands:
             echo 'TRIDENT_ANSWER_DATA=$HOME/answer_test_data' >> $BASH_ENV
             echo 'TRIDENT_CONFIG=$HOME/.trident/config.tri' >> $BASH_ENV
             echo 'YT_GOLD=8dcc2fa135dfe7a62438507066527caf5cb379c1' >> $BASH_ENV
-            echo 'YT_HEAD=yt-4.0' >> $BASH_ENV
+            echo 'YT_HEAD=master' >> $BASH_ENV
             echo 'TRIDENT_GOLD=test-standard-sph-viz-v6' >> $BASH_ENV
             echo 'TRIDENT_HEAD=tip' >> $BASH_ENV
 
@@ -43,6 +43,7 @@ commands:
             pip install --upgrade wheel
             pip install --upgrade setuptools
             pip install Cython numpy
+            export MAX_BUILD_CORES=2
             if [ << parameters.yttag >> != "None" ]; then
                 if [ ! -f $YT_DIR/README.md ]; then
                     git clone --branch=${YT_HEAD} https://github.com/yt-project/yt $YT_DIR


### PR DESCRIPTION
Set the yt branch for testing to master and only allow a maximum of two cores to build yt. This will prevent the issues where the build was hanging or being killed because it was trying to use the entire machine (which we are not allocated).