### PR TITLE
Bump the gold standard to fix test failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,9 +11,9 @@ commands:
             echo 'TRIDENT_ION_DATA=$HOME/.trident' >> $BASH_ENV
             echo 'TRIDENT_ANSWER_DATA=$HOME/answer_test_data' >> $BASH_ENV
             echo 'TRIDENT_CONFIG=$HOME/.trident/config.tri' >> $BASH_ENV
-            echo 'YT_GOLD=8dcc2fa135dfe7a62438507066527caf5cb379c1' >> $BASH_ENV
+            echo 'YT_GOLD=d218647162201673e8d0bc513a16b1b3add02a47' >> $BASH_ENV
             echo 'YT_HEAD=master' >> $BASH_ENV
-            echo 'TRIDENT_GOLD=test-standard-sph-viz-v6' >> $BASH_ENV
+            echo 'TRIDENT_GOLD=test-standard-v7' >> $BASH_ENV
             echo 'TRIDENT_HEAD=tip' >> $BASH_ENV
 
   install-dependencies:


### PR DESCRIPTION
We've had one single answer test failing in our test suite for a while now.  Given the amount of churn there has been in the yt4 branch as of late, this isn't *too* surprising.  I dug in a bit to figure out exactly what was wrong.  The failure was taking place in the test_absorption_spectrum.py: test_absorption_spectrum_non_cosmo_sph.  This test looks at a single snapshot from a gizmo output and generates a very simple absorption line spectrum using only Lyman alpha.  The spectrum has only a handful of low EW absorbers.

The difference is that in the newest version of yt/trident, there are very low-level ~1e-4 changes across a few of the absorbers, and a 1e-2 change across one of the features.  I've plotted these in the attached plots.  The first one shows the gold and new spectrum overplot on top of each other in blue and orange respectively.  As you can see, there are only two minor spots where the spectrum appear to diverge.  In green, I just show the residual difference between the two curves offset.  The second plot show the residual difference between the two curves in log space.  

![spectrum3](https://user-images.githubusercontent.com/8250999/85834497-59c78e00-b748-11ea-9bef-98f9acbd065c.png)

![spectrum_diff3](https://user-images.githubusercontent.com/8250999/85834496-592ef780-b748-11ea-87b3-10301328debe.png)

It's actually quite puzzling to me why these differences exist at all.  Furthermore, it seems odd that such changes would be confined to the results of a single answer test, when we run a number of different answer tests on particle-based and grid-based datasets.  Looking at the tests, we use slightly different precision levels to ensure agreement between the answer test results.  This particular test uses `decimals=16', but the other ones vary from 13-15.  But it seems weird because these are not even close to one part in 1e16 precision, as seen above, offset in one place by nearly 1 in 1e2 precision.  So presumably changes in the other tests would yield failures as well.

So overall, the changes aren't very substantial at all, and I think we can probably be OK just accepting that there was some modifications in all of the churn recently.  I guess it's a little weird that they're entirely confined to this one test, though.  It might be worth looking to see by what factor the other test results changed too, just to confirm that they're working correctly, but I'm too tired tonight.  

If/when we decide to accept this change, I can push the appropriate tag to the github master repo.