### PR TITLE
Fix the remaining missing images in the docs

### DIFF
--- a/doc/source/annotated_example.rst
+++ b/doc/source/annotated_example.rst
@@ -98,7 +98,7 @@ any volumentric plot, including slices, and off-axis plots::
     p.annotate_ray(ray, arrow=True)
     p.save('projection.png')
 
-.. image:: http://trident-project.org/data/doc_images/annotated_example/projection.png
+.. image:: trident-docs-images/annotated_example/projection.png
 
 .. _spectrum-generation:
 
@@ -124,7 +124,7 @@ plot it::
     sg.save_spectrum('spec_raw.txt')
     sg.plot_spectrum('spec_raw.png')
 
-.. image:: http://trident-project.org/data/doc_images/annotated_example/spec_raw.png
+.. image:: trident-docs-images/annotated_example/spec_raw.png
    :width: 700
 
 From here we can do some post-processing to the spectrum to include 
@@ -144,7 +144,7 @@ Finally, we use plot and save the resulting spectrum to disk::
 
 which produces:
 
-.. image:: http://trident-project.org/data/doc_images/annotated_example/spec_final.png
+.. image:: trident-docs-images/annotated_example/spec_final.png
    :width: 700
 
 To create more complex or ion-specific spectra, refer to :ref:`advanced-spectra`.

--- a/doc/source/ion_balance.rst
+++ b/doc/source/ion_balance.rst
@@ -83,7 +83,7 @@ of the O VI number density field to show its column density map::
 
 which produces:
 
-.. image:: http://trident-project.org/data/doc_images/ions/RD0009_Projection_z_O_p5_number_density.png
+.. image:: trident-docs-images/ions/RD0009_Projection_z_O_p5_number_density.png
 
 We can similarly create a phase plot to show where the O VI mass lives as a 
 function of density and temperature::
@@ -96,4 +96,4 @@ function of density and temperature::
 
 resulting in:
 
-.. image:: http://trident-project.org/data/doc_images/ions/RD0009_2d-Profile_density_temperature_O_p5_mass.png
+.. image:: trident-docs-images/ions/RD0009_2d-Profile_density_temperature_O_p5_mass.png


### PR DESCRIPTION
For some reason, readthedocs has recently started having problems rendering images pulled from directly linked URLs.  It used to work without problem, but now it is an issue that only shows up in the online-version of the docs.  Note, it isn't a problem in the PDF version of the docs that it produces.  Regardless, it's an issue that was identified in Issue #146.  

This was mostly addressed in PR #150, but it left out a few references to some of the docs images.  This PR updates all of the docs to point to the github repo instead of relying on the hardlinked URLs.  It should resolve the docs images problem once and for all.