### PR TITLE
Update the installation docs

### DIFF
--- a/doc/source/faq.rst
+++ b/doc/source/faq.rst
@@ -92,6 +92,8 @@ How do I cite Trident in my research?
 
 Check out our :ref:`citation <citation>` page.
 
+.. _slack-channel:
+
 How do I get an invite to the Trident slack channel?
 ----------------------------------------------------
 

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -112,8 +112,9 @@ the up-to-date version of the source code and build it::
     $ pip install -e .
     $ cd ..
 
-Note, you'll also need a separate library, yt_astro_analysis in order to
-have Trident work directly with yt:
+Note, you'll also need a separate library,
+`yt_astro_analysis <https://github.com/yt-project/yt_astro_analysis.git>`_,
+to get some of the functianality necessary for Trident to work correctly::
 
     $ git clone https://github.com/yt-project/yt_astro_analysis.git yt_astro_analysis
     $ cd yt_astro_analysis

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -35,7 +35,7 @@ Trident's Major Dependency: yt
 analysis and visualization of a different numerical datasets, including
 astrophysical hydrodynamical data.  yt is the primary dependency of Trident,
 so you must install it before Trident will work.  There are several methods
-for installing yt, which are all discussed in detail in the `yt installation 
+for installing yt, which are all discussed in detail in the `yt installation
 documentation <http://yt-project.org/doc/installing.html>`_.  Use the one
 that is appropriate for you.  We find that using
 `conda <https://docs.conda.io/en/latest/>`_ is the most streamlined and
@@ -73,7 +73,7 @@ Step 0: Ensure Conda is Installed
 
 Conda is a package manager providing a clean, stand-alone installation of
 python that is self-contained in its installation directory.  yt & trident
-require a modern installation of python to work.  conda provides that 
+require a modern installation of python to work.  conda provides that
 installation.
 
 You can see if conda is already installed by running:
@@ -102,11 +102,12 @@ $ wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
 $ bash Miniconda3-latest-Linux-x86_64.sh
 ```
 
-At the end of the installation step, allow conda to add its installation directory to the $PATH.
+At the end of the installation step, allow conda to add its installation
+directory to the $PATH.
 
 .. _step-1:
 
-Step 1: Install yt  
+Step 1: Install yt
 ^^^^^^^^^^^^^^^^^^
 
 First you need yt's major dependencies:
@@ -125,7 +126,7 @@ $ pip install -e .
 $ cd ..
 ```
 
-Note, you'll also need a separate library, yt_astro_analysis in order to 
+Note, you'll also need a separate library, yt_astro_analysis in order to
 have Trident work directly with yt.
 
 ```
@@ -157,20 +158,20 @@ $ cd ..
 Step 3: Get Ionization Table and Verify Installation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-In order to calculate the ionization fractions for various ions from 
-density, temperature, metallicity fields, you will need an ionization table 
+In order to calculate the ionization fractions for various ions from
+density, temperature, metallicity fields, you will need an ionization table
 datafile and a configuration file.  Because this datafile can be large, it is
 not packaged with the main source code.  The first time you try to do anything
-that requires it, Trident will attempt to automatically set this all up for 
-you with a series of interactive prompts.  **This step requires an internet 
+that requires it, Trident will attempt to automatically set this all up for
+you with a series of interactive prompts.  **This step requires an internet
 connection the first time you run it.**
 
-In addition, Trident provides a simple test function to verify that your 
+In addition, Trident provides a simple test function to verify that your
 install is functioning correctly.  This function not only tries to set up
-your configuration and download your ion table file, but it will 
-create a simple one-zone dataset, generate a ray through it, and 
-create a spectrum from that ray.  This should execute very quickly, 
-and if it succeeds it demonstrates that your installation has been totally 
+your configuration and download your ion table file, but it will
+create a simple one-zone dataset, generate a ray through it, and
+create a spectrum from that ray.  This should execute very quickly,
+and if it succeeds it demonstrates that your installation has been totally
 successful::
 
     $ python
@@ -179,7 +180,7 @@ successful::
     ...Series of Interactive Prompts...
 
 If you cannot directly access the internet on this computer, or you lack write
-access to your ``$HOME`` directory, or this step fails for any reason, please 
+access to your ``$HOME`` directory, or this step fails for any reason, please
 follow our documentation on :ref:`manual-config`.
 
 .. _step-4:
@@ -187,14 +188,14 @@ follow our documentation on :ref:`manual-config`.
 Step 4: Science!
 ^^^^^^^^^^^^^^^^
 
-Congratulations, you're now ready to use Trident!  Please refer to the 
-documentation for how to use it with your data or with one of our sample 
-datasets.  A good place to start is the 
+Congratulations, you're now ready to use Trident!  Please refer to the
+documentation for how to use it with your data or with one of our sample
+datasets.  A good place to start is the
 :ref:`annotated example <annotated-example>`, and the `example scripts found
-in the source code 
+in the source code
 <https://github.com/trident-project/trident/blob/master/examples>`_.
 
-Please join our :ref:`mailing list 
+Please join our :ref:`mailing list
 <mailing-list>` or :ref:`slack channel <slack-channel>` for announcements
 and updates when new features are added to the code.
 
@@ -205,27 +206,27 @@ Manually Installing your Ionization Table
 
 If for some reason you are unable to install the config file and ionization
 table data automatically, you must set it up manually.  When Trident runs,
-it looks for a configuration file called ``config.tri`` in the 
-``$HOME/.trident`` directory or alternatively in the current working 
-directory (for users lacking write access to their ``$HOME`` directories).  
-This configuration file is simple in that it tells Trident a few things about 
-your install including the location and filename of your desired ionization 
-table.  Manually create a text file called ``config.tri`` with contents 
-following the form::
+it looks for a configuration file called ``config.tri`` in the
+``$HOME/.trident`` directory or alternatively in the current working
+directory (for users lacking write access to their ``$HOME`` directories).
+This configuration file is simple in that it tells Trident a few things about
+your install including the location and filename of your desired ionization
+table.  Manually create a text file called ``config.tri`` with contents
+following the form:
 
     [Trident]
     ion_table_dir = ~/.trident
     ion_table_file = hm2012_hr.h5
 
 To manually obtain an ion table datafile, download and gunzip one from:
-http://trident-project.org/data/ion_table .  While the ``config.tri`` file needs 
-to exist in your ``$HOME/.trident`` directory or in the working directory
-when you import trident, the ion_table datafile can exist anywhere on the 
-file system.  Just assure that the config file points to the proper location 
+http://trident-project.org/data/ion_table .  While the ``config.tri`` file
+needs to exist in your ``$HOME/.trident`` directory or in the working directory
+when you import trident, the ion_table datafile can exist anywhere on the
+file system.  Just assure that the config file points to the proper location
 and filename of the ion table datafile.
 
 Now, to confirm everything is working properly, verify your installation
-following :ref:`step-3`.  If this fails or you have additional problems, 
+following :ref:`step-3`.  If this fails or you have additional problems,
 please contact our mailing list.
 
 .. _uninstallation:
@@ -249,8 +250,8 @@ If you want to switch between the two stable and development versions, just
 version as described in :ref:`install-trident`
 
 To fully remove the code from your system, remember to remove any ion table
-datafiles you may have downloaded in your ``$HOME/.trident`` directory, 
-and follow the instructions for how to `uninstall yt 
+datafiles you may have downloaded in your ``$HOME/.trident`` directory,
+and follow the instructions for how to `uninstall yt
 <http://yt-project.org/docs/dev/installing.html>`_.
 
 .. _updating:
@@ -259,12 +260,12 @@ Updating to the Latest Version
 ------------------------------
 
 If you want more recent features, you should periodically update your Trident
-codebase.  
+codebase.
 
 Updating to the Latest Stable Release
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If you installed the "stable" version of the code using pip, then 
+If you installed the "stable" version of the code using pip, then
 you can easily update your trident and yt installations::
 
     $ pip install -U trident
@@ -281,6 +282,6 @@ involved::
     $ pip install -e .
     $ yt update
 
-For more information on updating your yt installation, see the `yt update 
-instructions 
+For more information on updating your yt installation, see the `yt update
+instructions
 <http://yt-project.org/docs/dev/installing.html#updating-yt-and-its-dependencies>`_.

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -10,101 +10,152 @@ Follow these steps to successfully install Trident and its dependencies.
 Versions of Trident
 -------------------
 
-Previously, there were three versions of Trident: the `stable version
-<http://trident.readthedocs.io/en/stable>`_, the `developent version
-<http://trident.readthedocs.io/en/latest>`_, and the `demeshening version
-<https://nbviewer.jupyter.org/url/trident-project.org/notebooks/trident_demesh_install.ipynb>`_.
-The stable version is tried and tested, and it normally operates on a stable
-version of yt.  The development version is actively being updated with new
-features, and it is also tied to the development version of yt, so occasionally
-unforseen bugs can crop up as these new features are added.  The demeshening
-version is currently in beta and active development and is used for better
-results on particle-based datasets.
+There are currently two versions of Trident: a `stable version
+<http://trident.readthedocs.io/en/stable>`_ and a `development version
+<http://trident.readthedocs.io/en/latest>`_.  Make sure you are reading the
+correct docs for the version you are using!
 
-After Trident 1.2 was released on September 19, 2019, the demeshening version
-was merged with the main development branch. Now, there are only the stable
-version and the development version. 
+The stable version is tried
+and tested and easy to install with pip.  The development version is actively
+being updated with new features including superior support for particle-based
+datasets (previously known as the demeshening).  Note that the stable version
+of trident requires the stable version of yt, and the development version of
+trident requires the development version of yt, due to some
+backwards-incompatible changes regarding particle-support in yt/trident.
 
-The installation steps are slightly different between the two versions,
+Thus, the installation steps are slightly different for stable and development,
 so pay attention in the steps below.  Don't worry if you want to change later,
 you can always switch between the two versions easily enough by following the
 directions in :ref:`uninstallation`.
 
-.. note::
-    The demeshening (development) version treats particle-based
-    datasets more natively.  The demeshening version will give faster and more 
-    accurate results with less memory overhead for particle-based datasets.  
-    For more information about the demeshening version, please see our
-    `demeshening notebook
-    <https://nbviewer.jupyter.org/url/trident-project.org/notebooks/trident_demesh_install.ipynb>`_. **Note, the installation instructions in the notebook should be ignored.**
-    Instead, follow the instructions for :ref:`install-dev`.
+Trident's Major Dependency: yt
+------------------------------
+
+`yt <http://yt-project.org>`_ is a python-based software package for the
+analysis and visualization of a different numerical datasets, including
+astrophysical hydrodynamical data.  yt is the primary dependency of Trident,
+so you must install it before Trident will work.  There are several methods
+for installing yt, which are all discussed in detail in the `yt installation 
+documentation <http://yt-project.org/doc/installing.html>`_.  Use the one
+that is appropriate for you.  We find that using
+`conda <https://docs.conda.io/en/latest/>`_ is the most streamlined and
+reliable.
+
+.. _stable-trident:
+
+Installing the Stable Version of yt and Trident
+-----------------------------------------------
+
+Installation of the stable versions of yt and Trident is quite simple:
+
+```
+$ pip install yt
+$ pip install trident
+```
+
+Now, you can try to run Trident for the first time, where it will download
+some additional files.  See :ref:`step-3`, for more information.
+
+```
+$ python
+>>> import trident
+```
+
+Follow the instructions to download the ion_balance table and then verify that
+everything is working correctly.  You should now be ready to do some 
+:ref:`step-4`
+
+Installing the Development Version of yt and Trident
+----------------------------------------------------
+
+Step 0: Ensure Conda is Installed
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Conda is a package manager providing a clean, stand-alone installation of
+python that is self-contained in its installation directory.  yt & trident
+require a modern installation of python to work.  conda provides that 
+installation.
+
+You can see if conda is already installed by running:
+
+```
+$ conda -h
+```
+
+If conda is installed, move to the next step.  Otherwise install Mini-conda.
+
+Use the appropriate conda install script for your architecture.  We recommend
+getting the latest version of conda for Python3 for your architecture here:
+https://repo.continuum.io/miniconda/
+
+For modern macs:
+
+```
+$ curl -O https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
+$ bash Miniconda3-latest-MacOSX-x86_64.sh
+```
+
+For modern linux machines:
+
+```
+$ wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
+$ bash Miniconda3-latest-Linux-x86_64.sh
+```
+
+At the end of the installation step, allow conda to add its installation directory to the $PATH.
 
 .. _step-1:
 
 Step 1: Install yt  
-------------------
+^^^^^^^^^^^^^^^^^^
 
-`yt <http://yt-project.org>`_ is a python-based software package for the 
-analysis and visualization of a variety of different datasets, including 
-astrophysical hydrodynamical data.  yt is a dependency of Trident, so you
-must install it before Trident will work.  There are several methods for 
-installing yt, which are all discussed in detail in the `yt installation 
-documentation <http://yt-project.org/doc/installing.html>`_.  
+First you need yt's major dependencies:
 
-We find that the easiest way to install yt is with the all-in-one install 
-script, which installs yt and its dependencies via a new conda installation::
+```
+$ conda install numpy cython mpi4py git
+```
 
-    $ wget https://raw.githubusercontent.com/yt-project/yt/master/doc/install_script.sh
-    $ ... edit the install_script.sh to mark INST_SCIPY=1, INST_ASTROPY=1,
-    $ ... and INST_YT_SOURCE=1
-    $ bash install_script.sh
-    $ ... update your path flag as described by the install_script.sh
+Now you pull directly from the yt github repository to access
+the up-to-date version of the source code and build it.
 
-Alternatively, if you already have conda installed, you can skip the commands
-above and just run the following command to get yt and its dependencies.  
-To get the nightly build of the development version of yt, type::
+```
+$ git clone https://github.com/yt-project/yt.git yt
+$ cd yt
+$ pip install -e .
+$ cd ..
+```
 
-    $ conda install -c http://use.yt/with_conda/ -c conda-forge yt
+Note, you'll also need a separate library, yt_astro_analysis in order to 
+have Trident work directly with yt.
+
+```
+$ git clone https://github.com/yt-project/yt_astro_analysis.git yt_astro_analysis
+$ cd yt_astro_analysis
+$ pip install -e .
+$ cd ..
+```
 
 .. _install-trident:
 .. _step-2:
-
-Step 2: Install Trident
------------------------
-
-Installing the Stable Release
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-You can install the most recent stable release of Trident using pip::
-
-    $ pip install trident
-
 .. _install-dev:
 
-Installing the Development Version
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Step 2: Install Trident
+^^^^^^^^^^^^^^^^^^^^^^^
 
-To get the development version, you'll pull the source code from its 
-repository using git, which should be installed as part of your yt 
-installation.  If it isn't try: ``conda install git``.  After that, you'll 
-use pip to install the source directly. The development version of Trident
-requires the yt-4.0 development version of yt as well. Go to your desired
-source code installation directory and run::
+Like yt, in order to get the development version of Trident, you must clone
+and build the up-to-date source code from its repository.
 
-    $ # install yt
-    $ git clone https://github.com/yt-project/yt --branch=yt-4.0
-    $ cd yt
-    $ pip install -e .
-    $ cd ..
-    $ # install trident
-    $ git clone https://github.com/trident-project/trident
-    $ cd trident
-    $ pip install -e .
+```
+$ git clone https://github.com/trident-project/trident.git trident
+$ cd trident
+$ pip install -e .
+$ cd ..
+```
 
 .. _step-3:
 
 Step 3: Get Ionization Table and Verify Installation
-----------------------------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 In order to calculate the ionization fractions for various ions from 
 density, temperature, metallicity fields, you will need an ionization table 
@@ -134,12 +185,18 @@ follow our documentation on :ref:`manual-config`.
 .. _step-4:
 
 Step 4: Science!
-----------------
+^^^^^^^^^^^^^^^^
 
 Congratulations, you're now ready to use Trident!  Please refer to the 
 documentation for how to use it with your data or with one of our sample 
-datasets.  Please join our :ref:`mailing list 
-<mailing-list>` for announcements and when new features are added to the code.
+datasets.  A good place to start is the 
+:ref:`annotated example <annotated-example>`, and the `example scripts found
+in the source code 
+<https://github.com/trident-project/trident/blob/master/examples>`_.
+
+Please join our :ref:`mailing list 
+<mailing-list>` or :ref:`slack channel <slack-channel>` for announcements
+and updates when new features are added to the code.
 
 .. _manual-config:
 
@@ -185,7 +242,7 @@ If you installed the dev version of Trident, you'll have to delete the source
 as well::
 
     $ pip uninstall trident
-    $ rm -rf </path/to/trident/repo>
+    $ rm -rf <YOUR_PATH_TO_TRIDENT_REPO>
 
 If you want to switch between the two stable and development versions, just
 *uninstall* your version of the code as above, and then install the desired
@@ -219,7 +276,7 @@ Updating to the Latest Development Version
 If you installed the "development" version of the code, it's slightly more
 involved::
 
-    $ cd <path/to/trident/repo>
+    $ cd <YOUR_PATH_TO_TRIDENT_REPO>
     $ git pull origin master
     $ pip install -e .
     $ yt update

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -46,20 +46,16 @@ reliable.
 Installing the Stable Version of yt and Trident
 -----------------------------------------------
 
-Installation of the stable versions of yt and Trident is quite simple:
+Installation of the stable versions of yt and Trident is quite simple::
 
-```
-$ pip install yt
-$ pip install trident
-```
+    $ pip install yt
+    $ pip install trident
 
 Now, you can try to run Trident for the first time, where it will download
-some additional files.  See :ref:`step-3`, for more information.
+some additional files.  See :ref:`step-3`, for more information::
 
-```
-$ python
->>> import trident
-```
+    $ python
+    >>> import trident
 
 Follow the instructions to download the ion_balance table and then verify that
 everything is working correctly.  You should now be ready to do some 
@@ -76,11 +72,9 @@ python that is self-contained in its installation directory.  yt & trident
 require a modern installation of python to work.  conda provides that
 installation.
 
-You can see if conda is already installed by running:
+You can see if conda is already installed by running::
 
-```
-$ conda -h
-```
+    $ conda -h
 
 If conda is installed, move to the next step.  Otherwise install Mini-conda.
 
@@ -88,19 +82,15 @@ Use the appropriate conda install script for your architecture.  We recommend
 getting the latest version of conda for Python3 for your architecture here:
 https://repo.continuum.io/miniconda/
 
-For modern macs:
+For modern macs::
 
-```
-$ curl -O https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
-$ bash Miniconda3-latest-MacOSX-x86_64.sh
-```
+    $ curl -O https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
+    $ bash Miniconda3-latest-MacOSX-x86_64.sh
 
-For modern linux machines:
+For modern linux machines::
 
-```
-$ wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
-$ bash Miniconda3-latest-Linux-x86_64.sh
-```
+    $ wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
+    $ bash Miniconda3-latest-Linux-x86_64.sh
 
 At the end of the installation step, allow conda to add its installation
 directory to the $PATH.
@@ -110,31 +100,25 @@ directory to the $PATH.
 Step 1: Install yt
 ^^^^^^^^^^^^^^^^^^
 
-First you need yt's major dependencies:
+First you need yt's major dependencies::
 
-```
-$ conda install numpy cython mpi4py git
-```
+    $ conda install numpy cython mpi4py git
 
 Now you pull directly from the yt github repository to access
-the up-to-date version of the source code and build it.
+the up-to-date version of the source code and build it::
 
-```
-$ git clone https://github.com/yt-project/yt.git yt
-$ cd yt
-$ pip install -e .
-$ cd ..
-```
+    $ git clone https://github.com/yt-project/yt.git yt
+    $ cd yt
+    $ pip install -e .
+    $ cd ..
 
 Note, you'll also need a separate library, yt_astro_analysis in order to
-have Trident work directly with yt.
+have Trident work directly with yt:
 
-```
-$ git clone https://github.com/yt-project/yt_astro_analysis.git yt_astro_analysis
-$ cd yt_astro_analysis
-$ pip install -e .
-$ cd ..
-```
+    $ git clone https://github.com/yt-project/yt_astro_analysis.git yt_astro_analysis
+    $ cd yt_astro_analysis
+    $ pip install -e .
+    $ cd ..
 
 .. _install-trident:
 .. _step-2:
@@ -144,14 +128,12 @@ Step 2: Install Trident
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 Like yt, in order to get the development version of Trident, you must clone
-and build the up-to-date source code from its repository.
+and build the up-to-date source code from its repository::
 
-```
-$ git clone https://github.com/trident-project/trident.git trident
-$ cd trident
-$ pip install -e .
-$ cd ..
-```
+    $ git clone https://github.com/trident-project/trident.git trident
+    $ cd trident
+    $ pip install -e .
+    $ cd ..
 
 .. _step-3:
 
@@ -212,7 +194,7 @@ directory (for users lacking write access to their ``$HOME`` directories).
 This configuration file is simple in that it tells Trident a few things about
 your install including the location and filename of your desired ionization
 table.  Manually create a text file called ``config.tri`` with contents
-following the form:
+following the form::
 
     [Trident]
     ion_table_dir = ~/.trident


### PR DESCRIPTION
This is an attempt to streamline and update the installation documentation.  It removes reference to the demesh notebook and integrates what was included there into the standard docs.