### PR TITLE
Fixing API docs

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -25,7 +25,7 @@ import glob
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-needs_sphinx = '3.2.1'
+needs_sphinx = '3.4.3'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -25,7 +25,7 @@ import glob
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-#needs_sphinx = '1.0'
+needs_sphinx = '3.2.1'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom

--- a/environment.yml
+++ b/environment.yml
@@ -30,6 +30,7 @@ dependencies:
     - python-dateutil==2.8.0
     - requests==2.22.0
     - scipy==1.0.1
+    - sphinx==3.2.1
     - sympy==1.4
     - traitlets==4.3.2
     - urllib3==1.25.3

--- a/environment.yml
+++ b/environment.yml
@@ -30,7 +30,7 @@ dependencies:
     - python-dateutil==2.8.0
     - requests==2.22.0
     - scipy==1.0.1
-    - sphinx==3.2.1
+    - sphinx==3.4.3
     - sympy==1.4
     - traitlets==4.3.2
     - urllib3==1.25.3


### PR DESCRIPTION
Recently, the API docs in the dev tip began failing spontaneously.  

Essentially, they went from this: https://trident.readthedocs.io/en/stable/reference.html

to this: https://trident.readthedocs.io/en/latest/reference.html

I dug in and couldn't figure out why, because nothing had seemed to change on our front.  @matthewturk pointed out that a bug was introduced in Sphinx recently that causes this behavior in their latest version.  One way to address this problem is simply to pin the sphinx version to a slightly older version to be installed and used by readthedocs.  This PR attempts to do this by changing the conda environment to explicitly use this older version of sphinx and require it in the readthedocs build.