### PR TITLE
Cleaning up deprecation warnings

### DIFF
--- a/tests/test_absorption_spectrum.py
+++ b/tests/test_absorption_spectrum.py
@@ -60,7 +60,9 @@ class AbsorptionSpectrumTest(TempDirTest):
         lr = LightRay(COSMO_PLUS, 'Enzo', 0.0, 0.03)
 
         lr.make_light_ray(seed=1234567,
-                          fields=['temperature', 'density', 'H_p0_number_density'],
+                          fields=[('gas', 'temperature'),
+                                  ('gas', 'density',),
+                                  ('gas', 'H_p0_number_density'],
                           data_filename='lightray.h5')
 
         sp = AbsorptionSpectrum(900.0, 1800.0, 10000)
@@ -86,7 +88,7 @@ class AbsorptionSpectrumTest(TempDirTest):
         filename = "spectrum.h5"
         wavelength, flux = sp.make_spectrum('lightray.h5',
                                             output_file=filename,
-                                            line_list_file='lines.txt',
+                                            output_absorbers_file='lines.txt',
                                             use_peculiar_velocity=True)
         return filename
 
@@ -102,7 +104,9 @@ class AbsorptionSpectrumTest(TempDirTest):
         ray_start = [0,0,0]
         ray_end = [1,1,1]
         lr.make_light_ray(start_position=ray_start, end_position=ray_end,
-                          fields=['temperature', 'density', 'H_p0_number_density'],
+                          fields=[('gas', 'temperature'),
+                                  ('gas', 'density',),
+                                  ('gas', 'H_p0_number_density'],
                           data_filename='lightray.h5')
 
         sp = AbsorptionSpectrum(1200.0, 1300.0, 10001)
@@ -120,7 +124,7 @@ class AbsorptionSpectrumTest(TempDirTest):
         filename = "spectrum.h5"
         wavelength, flux = sp.make_spectrum('lightray.h5',
                                             output_file=filename,
-                                            line_list_file='lines.txt',
+                                            output_absorbers_file='lines.txt',
                                             use_peculiar_velocity=True)
         return filename
 
@@ -136,7 +140,9 @@ class AbsorptionSpectrumTest(TempDirTest):
         ray_start = [0,0,0]
         ray_end = [1,1,1]
         lr.make_light_ray(start_position=ray_start, end_position=ray_end,
-                          fields=['temperature', 'density', 'H_p0_number_density'],
+                          fields=[('gas', 'temperature'),
+                                  ('gas', 'density',),
+                                  ('gas', 'H_p0_number_density'],
                           data_filename='lightray.h5', use_peculiar_velocity=False)
 
         sp = AbsorptionSpectrum(1200.0, 1300.0, 10001)
@@ -154,7 +160,7 @@ class AbsorptionSpectrumTest(TempDirTest):
         filename = "spectrum.h5"
         wavelength, flux = sp.make_spectrum('lightray.h5',
                                             output_file=filename,
-                                            line_list_file='lines.txt',
+                                            output_absorbers_file='lines.txt',
                                             use_peculiar_velocity=False)
         return filename
 
@@ -170,7 +176,9 @@ class AbsorptionSpectrumTest(TempDirTest):
         ray_start = [0,0,0]
         ray_end = [1,1,1]
         lr.make_light_ray(start_position=ray_start, end_position=ray_end,
-                          fields=['temperature', 'density', 'H_p0_number_density'],
+                          fields=[('gas', 'temperature'),
+                                  ('gas', 'density',),
+                                  ('gas', 'H_p0_number_density'],
                           data_filename='lightray.h5')
 
         my_label = 'HI Lya'
@@ -207,7 +215,9 @@ class AbsorptionSpectrumTest(TempDirTest):
         ray_start = [0,0,0]
         ray_end = [1,1,1]
         lr.make_light_ray(start_position=ray_start, end_position=ray_end,
-                          fields=['temperature', 'density', 'H_p0_number_density'],
+                          fields=[('gas', 'temperature'),
+                                  ('gas', 'density',),
+                                  ('gas', 'H_p0_number_density'],
                           data_filename='lightray.h5')
 
         sp = AbsorptionSpectrum(900.0, 1800.0, 10000)
@@ -232,7 +242,7 @@ class AbsorptionSpectrumTest(TempDirTest):
 
         wavelength, flux = sp.make_spectrum('lightray.h5',
                                             output_file='spectrum.fits',
-                                            line_list_file='lines.txt',
+                                            output_absorbers_file='lines.txt',
                                             use_peculiar_velocity=True)
 
     @h5_answer_test(assert_array_rel_equal, decimals=12)
@@ -272,7 +282,7 @@ class AbsorptionSpectrumTest(TempDirTest):
         filename = "spectrum.h5"
         wavelength, flux = sp.make_spectrum('lightray.h5',
                                             output_file=filename,
-                                            line_list_file='lines.txt',
+                                            output_absorbers_file='lines.txt',
                                             use_peculiar_velocity=True)
         return filename
 
@@ -307,7 +317,7 @@ class AbsorptionSpectrumTest(TempDirTest):
         filename = "spectrum.h5"
         wavelength, flux = sp.make_spectrum('lightray.h5',
                                             output_file=filename,
-                                            line_list_file='lines.txt',
+                                            output_absorbers_file='lines.txt',
                                             use_peculiar_velocity=True)
         return filename
 
@@ -324,7 +334,9 @@ class AbsorptionSpectrumTest(TempDirTest):
         ray_start = ds.domain_left_edge
         ray_end = ds.domain_right_edge
         lr.make_light_ray(start_position=ray_start, end_position=ray_end,
-                          fields=['temperature', 'density', 'H_p0_number_density'],
+                          fields=[('gas', 'temperature'),
+                                  ('gas', 'density',),
+                                  ('gas', 'H_p0_number_density'],
                           data_filename='lightray.h5')
 
         sp = AbsorptionSpectrum(800.0, 1300.0, 5001)
@@ -350,7 +362,7 @@ class AbsorptionSpectrumTest(TempDirTest):
         filename = "spectrum.h5"
         wavelength, flux = sp.make_spectrum('lightray.h5',
                                             output_file=filename,
-                                            line_list_file='lines.txt',
+                                            output_absorbers_file=None,
                                             use_peculiar_velocity=True)
         return filename
 
@@ -423,5 +435,5 @@ class AbsorptionSpectrumTest(TempDirTest):
         wavelength, flux = sp.make_spectrum(
             'test_lightray.h5',
             output_file='test_spectrum.h5',
-            line_list_file='test_lines.txt',
+            output_absorbers_file='test_lines.txt',
             use_peculiar_velocity=True)

--- a/tests/test_absorption_spectrum.py
+++ b/tests/test_absorption_spectrum.py
@@ -352,7 +352,7 @@ class AbsorptionSpectrumTest(TempDirTest):
                     gamma, mass, label_threshold=1.e10)
 
         my_label = 'Ly C'
-        field = ('gas', 'H_p0_number_density')
+        field = ('gas', 'H_p0_number_density'),
         wavelength = 912.323660  # Angstroms
         normalization = 1.6e17
         index = 3.0
@@ -362,7 +362,7 @@ class AbsorptionSpectrumTest(TempDirTest):
         filename = "spectrum.h5"
         wavelength, flux = sp.make_spectrum('lightray.h5',
                                             output_file=filename,
-                                            output_absorbers_file=None,
+                                            output_absorbers_file='lines.txt',
                                             use_peculiar_velocity=True)
         return filename
 
@@ -384,7 +384,7 @@ class AbsorptionSpectrumTest(TempDirTest):
 
         HI_parameters = {
             'name': 'HI',
-            'field': ('gas', 'H_p0_number_density')
+            'field': ('gas', 'H_p0_number_density'),
             'f': [.4164],
             'Gamma': [6.265E8],
             'wavelength': [1215.67],

--- a/tests/test_absorption_spectrum.py
+++ b/tests/test_absorption_spectrum.py
@@ -68,7 +68,7 @@ class AbsorptionSpectrumTest(TempDirTest):
         sp = AbsorptionSpectrum(900.0, 1800.0, 10000)
 
         my_label = 'HI Lya'
-        field = 'H_p0_number_density'
+        field = ('gas', 'H_p0_number_density')
         wavelength = 1215.6700  # Angstromss
         f_value = 4.164E-01
         gamma = 6.265e+08
@@ -78,7 +78,7 @@ class AbsorptionSpectrumTest(TempDirTest):
                     gamma, mass, label_threshold=1.e10)
 
         my_label = 'HI Lya'
-        field = 'H_p0_number_density'
+        field = ('gas', 'H_p0_number_density')
         wavelength = 912.323660  # Angstroms
         normalization = 1.6e17
         index = 3.0
@@ -112,7 +112,7 @@ class AbsorptionSpectrumTest(TempDirTest):
         sp = AbsorptionSpectrum(1200.0, 1300.0, 10001)
 
         my_label = 'HI Lya'
-        field = 'H_p0_number_density'
+        field = ('gas', 'H_p0_number_density')
         wavelength = 1215.6700  # Angstromss
         f_value = 4.164E-01
         gamma = 6.265e+08
@@ -148,7 +148,7 @@ class AbsorptionSpectrumTest(TempDirTest):
         sp = AbsorptionSpectrum(1200.0, 1300.0, 10001)
 
         my_label = 'HI Lya'
-        field = 'H_p0_number_density'
+        field = ('gas', 'H_p0_number_density')
         wavelength = 1215.6700  # Angstromss
         f_value = 4.164E-01
         gamma = 6.265e+08
@@ -182,7 +182,7 @@ class AbsorptionSpectrumTest(TempDirTest):
                           data_filename='lightray.h5')
 
         my_label = 'HI Lya'
-        field = 'H_p0_number_density'
+        field = ('gas', 'H_p0_number_density')
         wave = 1215.6700  # Angstromss
         f_value = 4.164E-01
         gamma = 6.265e+08
@@ -223,7 +223,7 @@ class AbsorptionSpectrumTest(TempDirTest):
         sp = AbsorptionSpectrum(900.0, 1800.0, 10000)
 
         my_label = 'HI Lya'
-        field = 'H_p0_number_density'
+        field = ('gas', 'H_p0_number_density')
         wavelength = 1215.6700  # Angstromss
         f_value = 4.164E-01
         gamma = 6.265e+08
@@ -233,7 +233,7 @@ class AbsorptionSpectrumTest(TempDirTest):
                     gamma, mass, label_threshold=1.e10)
 
         my_label = 'HI Lya'
-        field = 'H_p0_number_density'
+        field = ('gas', 'H_p0_number_density')
         wavelength = 912.323660  # Angstroms
         normalization = 1.6e17
         index = 3.0
@@ -342,7 +342,7 @@ class AbsorptionSpectrumTest(TempDirTest):
         sp = AbsorptionSpectrum(800.0, 1300.0, 5001)
 
         my_label = 'HI Lya'
-        field = 'H_p0_number_density'
+        field = ('gas', 'H_p0_number_density')
         wavelength = 1215.6700  # Angstromss
         f_value = 4.164E-01
         gamma = 6.265e+08
@@ -352,7 +352,7 @@ class AbsorptionSpectrumTest(TempDirTest):
                     gamma, mass, label_threshold=1.e10)
 
         my_label = 'Ly C'
-        field = 'H_p0_number_density'
+        field = ('gas', 'H_p0_number_density')
         wavelength = 912.323660  # Angstroms
         normalization = 1.6e17
         index = 3.0
@@ -384,7 +384,7 @@ class AbsorptionSpectrumTest(TempDirTest):
 
         HI_parameters = {
             'name': 'HI',
-            'field': 'H_p0_number_density',
+            'field': ('gas', 'H_p0_number_density')
             'f': [.4164],
             'Gamma': [6.265E8],
             'wavelength': [1215.67],

--- a/tests/test_absorption_spectrum.py
+++ b/tests/test_absorption_spectrum.py
@@ -352,7 +352,7 @@ class AbsorptionSpectrumTest(TempDirTest):
                     gamma, mass, label_threshold=1.e10)
 
         my_label = 'Ly C'
-        field = ('gas', 'H_p0_number_density'),
+        field = ('gas', 'H_p0_number_density')
         wavelength = 912.323660  # Angstroms
         normalization = 1.6e17
         index = 3.0

--- a/tests/test_absorption_spectrum.py
+++ b/tests/test_absorption_spectrum.py
@@ -286,7 +286,7 @@ class AbsorptionSpectrumTest(TempDirTest):
                                             use_peculiar_velocity=True)
         return filename
 
-    @h5_answer_test(assert_array_rel_equal, decimals=16)
+    @h5_answer_test(assert_array_rel_equal, decimals=15)
     def test_absorption_spectrum_non_cosmo_sph(self):
         """
         This test generates an absorption spectrum from a simple light ray on a

--- a/tests/test_absorption_spectrum.py
+++ b/tests/test_absorption_spectrum.py
@@ -61,8 +61,8 @@ class AbsorptionSpectrumTest(TempDirTest):
 
         lr.make_light_ray(seed=1234567,
                           fields=[('gas', 'temperature'),
-                                  ('gas', 'density',),
-                                  ('gas', 'H_p0_number_density'],
+                                  ('gas', 'density'),
+                                  ('gas', 'H_p0_number_density')],
                           data_filename='lightray.h5')
 
         sp = AbsorptionSpectrum(900.0, 1800.0, 10000)
@@ -105,8 +105,8 @@ class AbsorptionSpectrumTest(TempDirTest):
         ray_end = [1,1,1]
         lr.make_light_ray(start_position=ray_start, end_position=ray_end,
                           fields=[('gas', 'temperature'),
-                                  ('gas', 'density',),
-                                  ('gas', 'H_p0_number_density'],
+                                  ('gas', 'density'),
+                                  ('gas', 'H_p0_number_density')],
                           data_filename='lightray.h5')
 
         sp = AbsorptionSpectrum(1200.0, 1300.0, 10001)
@@ -141,8 +141,8 @@ class AbsorptionSpectrumTest(TempDirTest):
         ray_end = [1,1,1]
         lr.make_light_ray(start_position=ray_start, end_position=ray_end,
                           fields=[('gas', 'temperature'),
-                                  ('gas', 'density',),
-                                  ('gas', 'H_p0_number_density'],
+                                  ('gas', 'density'),
+                                  ('gas', 'H_p0_number_density')],
                           data_filename='lightray.h5', use_peculiar_velocity=False)
 
         sp = AbsorptionSpectrum(1200.0, 1300.0, 10001)
@@ -177,8 +177,8 @@ class AbsorptionSpectrumTest(TempDirTest):
         ray_end = [1,1,1]
         lr.make_light_ray(start_position=ray_start, end_position=ray_end,
                           fields=[('gas', 'temperature'),
-                                  ('gas', 'density',),
-                                  ('gas', 'H_p0_number_density'],
+                                  ('gas', 'density'),
+                                  ('gas', 'H_p0_number_density')],
                           data_filename='lightray.h5')
 
         my_label = 'HI Lya'
@@ -216,8 +216,8 @@ class AbsorptionSpectrumTest(TempDirTest):
         ray_end = [1,1,1]
         lr.make_light_ray(start_position=ray_start, end_position=ray_end,
                           fields=[('gas', 'temperature'),
-                                  ('gas', 'density',),
-                                  ('gas', 'H_p0_number_density'],
+                                  ('gas', 'density'),
+                                  ('gas', 'H_p0_number_density')],
                           data_filename='lightray.h5')
 
         sp = AbsorptionSpectrum(900.0, 1800.0, 10000)
@@ -335,8 +335,8 @@ class AbsorptionSpectrumTest(TempDirTest):
         ray_end = ds.domain_right_edge
         lr.make_light_ray(start_position=ray_start, end_position=ray_end,
                           fields=[('gas', 'temperature'),
-                                  ('gas', 'density',),
-                                  ('gas', 'H_p0_number_density'],
+                                  ('gas', 'density'),
+                                  ('gas', 'H_p0_number_density')],
                           data_filename='lightray.h5')
 
         sp = AbsorptionSpectrum(800.0, 1300.0, 5001)

--- a/tests/test_light_ray.py
+++ b/tests/test_light_ray.py
@@ -55,7 +55,9 @@ class LightRayTest(TempDirTest):
         lr = LightRay(COSMO_PLUS, 'Enzo', 0.0, 0.03)
 
         lr.make_light_ray(seed=1234567,
-                          fields=['temperature', 'density', 'H_p0_number_density'],
+                          fields=[('gas', 'temperature'),
+                                  ('gas', 'density'),
+                                  ('gas', 'H_p0_number_density')],
                           data_filename='lightray.h5')
 
         ds = load('lightray.h5')
@@ -71,7 +73,9 @@ class LightRayTest(TempDirTest):
         lr = LightRay(COSMO_PLUS, 'Enzo', 0.0, 0.03)
 
         lr.make_light_ray(seed=1234567, left_edge=left, right_edge=right,
-                          fields=['temperature', 'density', 'H_p0_number_density'],
+                          fields=[('gas', 'temperature'),
+                                  ('gas', 'density'),
+                                  ('gas', 'H_p0_number_density')],
                           data_filename='lightray.h5')
 
         ds = load('lightray.h5')
@@ -84,7 +88,9 @@ class LightRayTest(TempDirTest):
         lr = LightRay(COSMO_PLUS, 'Enzo', 0.0, 0.03)
 
         lr.make_light_ray(seed=1234567, periodic=False,
-                          fields=['temperature', 'density', 'H_p0_number_density'],
+                          fields=[('gas', 'temperature'),
+                                  ('gas', 'density'),
+                                  ('gas', 'H_p0_number_density')],
                           data_filename='lightray.h5')
 
         ds = load('lightray.h5')
@@ -99,7 +105,9 @@ class LightRayTest(TempDirTest):
         ray_start = [0,0,0]
         ray_end = [1,1,1]
         lr.make_light_ray(start_position=ray_start, end_position=ray_end,
-                          fields=['temperature', 'density', 'H_p0_number_density'],
+                          fields=[('gas', 'temperature'),
+                                  ('gas', 'density'),
+                                  ('gas', 'H_p0_number_density')],
                           data_filename='lightray.h5')
 
         ds = load('lightray.h5')
@@ -112,8 +120,8 @@ class LightRayTest(TempDirTest):
         """
         ds = load(COSMO_PLUS_SINGLE)
         ray = make_simple_ray(ds, start_position=ds.domain_left_edge, end_position=ds.domain_right_edge, lines=['H'])
-        assert_almost_equal(ray.r['redshift'][0], 6.99900695e-03, decimal=8)
-        assert_almost_equal(ray.r['redshift'][-1], -1.08961751e-02, decimal=8)
+        assert_almost_equal(ray.r[('gas', 'redshift')][0], 6.99900695e-03, decimal=8)
+        assert_almost_equal(ray.r[('gas', 'redshift')][-1], -1.08961751e-02, decimal=8)
 
     def test_light_ray_non_cosmo_from_dataset(self):
         """
@@ -126,7 +134,9 @@ class LightRayTest(TempDirTest):
         ray_start = [0,0,0]
         ray_end = [1,1,1]
         lr.make_light_ray(start_position=ray_start, end_position=ray_end,
-                          fields=['temperature', 'density', 'H_p0_number_density'],
+                          fields=[('gas', 'temperature'),
+                                  ('gas', 'density'),
+                                  ('gas', 'H_p0_number_density')],
                           data_filename='lightray.h5')
 
         ds = load('lightray.h5')
@@ -139,8 +149,8 @@ class LightRayTest(TempDirTest):
         """
         ds = load(GIZMO_COSMO_SINGLE)
         ray = make_simple_ray(ds, start_position=ds.domain_left_edge, end_position=ds.domain_right_edge, lines=['H'])
-        assert_almost_equal(ray.r['redshift'][0], 0.00489571, decimal=8)
-        assert_almost_equal(ray.r['redshift'][-1], -0.00416831, decimal=8)
+        assert_almost_equal(ray.r[('gas', 'redshift')][0], 0.00489571, decimal=8)
+        assert_almost_equal(ray.r[('gas', 'redshift')][-1], -0.00416831, decimal=8)
 
     def test_light_ray_redshift_monotonic(self):
         """
@@ -150,4 +160,4 @@ class LightRayTest(TempDirTest):
         ds = load(COSMO_PLUS_SINGLE)
         ray = make_simple_ray(ds, start_position=ds.domain_center,
                               end_position=ds.domain_center+ds.domain_width)
-        assert((np.diff(ray.data['redshift']) < 0).all())
+        assert((np.diff(ray.data[('gas', 'redshift')]) < 0).all())

--- a/tests/test_line_database.py
+++ b/tests/test_line_database.py
@@ -41,7 +41,7 @@ def test_uniquify():
 
 def test_line():
     HI = Line('H', 'I', 1216, 1.5, 2.3, identifier='Ly a')
-    assert HI.field == "H_p0_number_density"
+    assert HI.field == ('gas', "H_p0_number_density")
     print(HI)
 
 def test_line_database_from_stored_file():

--- a/trident/absorption_spectrum/absorption_spectrum.py
+++ b/trident/absorption_spectrum/absorption_spectrum.py
@@ -795,8 +795,7 @@ class AbsorptionSpectrum(object):
 
             # a note to the user about which lines components are unresolved
             if (my_width < self.bin_width).any():
-                mylog.info("%d out of %d line components will be " +
-                            "deposited as unresolved lines.",
+                mylog.info("%d out of %d line components are unresolved.",
                             (my_width < self.bin_width).sum(),
                             n_absorbers)
 

--- a/trident/absorption_spectrum/absorption_spectrum.py
+++ b/trident/absorption_spectrum/absorption_spectrum.py
@@ -879,9 +879,8 @@ class AbsorptionSpectrum(object):
 
                     if my_vbins.size > 1e6:
                         mylog.warning(
-                            ('About to deposit a line with %d bins.' +
-                             'This may take a while. You might want to consider ' +
-                             'increasing the bin size.') % my_vbins.size)
+                            ('Depositing line with %d bins may be slow. ' +
+                             'Increase bin size?') % my_vbins.size)
 
                     # the virtual bins and their corresponding opacities
                     my_vbins, vtau = \

--- a/trident/absorption_spectrum/absorption_spectrum.py
+++ b/trident/absorption_spectrum/absorption_spectrum.py
@@ -439,16 +439,20 @@ class AbsorptionSpectrum(object):
                        "'output_absorbers_file'.")
             output_absorbers_file = line_list_file
 
-        input_fields = ['dl', 'redshift', 'temperature']
-        field_units = {"dl": "cm", "redshift": "", "temperature": "K"}
+        input_fields = [('gas', 'dl'),
+                        ('gas', 'redshift'),
+                        ('gas', 'temperature')]
+        field_units = {('gas', 'dl'): "cm",
+                       ('gas', 'redshift'): "",
+                       ('gas', 'temperature'): "K"}
         if use_peculiar_velocity:
-            input_fields.append('velocity_los')
-            input_fields.append('redshift_eff')
-            field_units["velocity_los"] = "cm/s"
-            field_units["redshift_eff"] = ""
+            input_fields.append(('gas', 'velocity_los'))
+            input_fields.append(('gas', 'redshift_eff'))
+            field_units[('gas', 'velocity_los')] = "cm/s"
+            field_units[('redshift_eff')] = ""
         if observing_redshift != 0.:
-            input_fields.append('redshift_dopp')
-            field_units["redshift_dopp"] = ""
+            input_fields.append(('gas', 'redshift_dopp'))
+            field_units[('gas', 'redshift_dopp')] = ""
         for feature in self.line_list + self.continuum_list:
             if not feature['field_name'] in input_fields:
                 input_fields.append(feature['field_name'])
@@ -472,8 +476,7 @@ class AbsorptionSpectrum(object):
             self.zero_redshift = getattr(input_ds, 'current_redshift', 0)
 
         # temperature field required to calculate voigt profile widths
-        if ('temperature' not in input_ds.derived_field_list) and \
-           (('gas', 'temperature') not in input_ds.derived_field_list):
+        if ('gas', 'temperature') not in input_ds.derived_field_list:
             raise RuntimeError(
                 "('gas', 'temperature') field required to be present in %s "
                 "for AbsorptionSpectrum to function." % str(input_object))
@@ -555,14 +558,14 @@ class AbsorptionSpectrum(object):
             # This is already assumed in the generation of the LightRay
             redshift = field_data['redshift']
             if use_peculiar_velocity:
-                redshift_eff = field_data['redshift_eff']
+                redshift_eff = field_data[('gas', 'redshift_eff')]
         else:
             # The intermediate redshift that is seen by an observer
             # at a redshift other than z=0 is z12, where z1 is the
             # observing redshift and z2 is the emitted photon's redshift
             # Hogg (2000) eq. 13:
             # 1 + z12 = (1 + z2) / (1 + z1)
-            redshift = ((1 + field_data['redshift']) / \
+            redshift = ((1 + field_data[('gas', 'redshift')]) / \
                         (1 + observing_redshift)) - 1.
             # Combining cosmological redshift and doppler redshift
             # into an effective redshift is found in Peacock's
@@ -570,7 +573,7 @@ class AbsorptionSpectrum(object):
             # 1 + z_eff = (1 + z_cosmo) * (1 + z_doppler)
             if use_peculiar_velocity:
                 redshift_eff = ((1 + redshift) * \
-                                (1 + field_data['redshift_dopp'])) - 1.
+                                (1 + field_data[('gas', 'redshift_dopp')])) - 1.
 
         if not use_peculiar_velocity:
             redshift_eff = redshift
@@ -758,9 +761,9 @@ class AbsorptionSpectrum(object):
             if store_observables:
                 tau_ray = np.zeros(cdens.size)
             if use_peculiar_velocity:
-                vlos = field_data['velocity_los'].in_units("km/s").d # km/s
+                vlos = field_data[('gas', 'velocity_los')].in_units("km/s").d # km/s
             else:
-                vlos = np.zeros(field_data['temperature'].size)
+                vlos = np.zeros(field_data[('gas', 'temperature')].size)
 
             # When we actually deposit the voigt profile, sometimes we will
             # have underresolved lines (ie lines with smaller widths than

--- a/trident/absorption_spectrum/absorption_spectrum.py
+++ b/trident/absorption_spectrum/absorption_spectrum.py
@@ -556,7 +556,7 @@ class AbsorptionSpectrum(object):
         """
         if observing_redshift == 0.:
             # This is already assumed in the generation of the LightRay
-            redshift = field_data['redshift']
+            redshift = field_data[('gas', 'redshift')]
             if use_peculiar_velocity:
                 redshift_eff = field_data[('gas', 'redshift_eff')]
         else:
@@ -613,7 +613,7 @@ class AbsorptionSpectrum(object):
         # significantly to a continuum (see below).  because lots of
         # low column density absorbers can add up to a significant
         # continuum effect, we normalize min_tau by the n_absorbers.
-        n_absorbers = field_data['dl'].size
+        n_absorbers = field_data[('gas', 'dl')].size
 
         if n_absorbers == 0:
             mylog.info("No absorbers in path of LightRay.")
@@ -625,7 +625,7 @@ class AbsorptionSpectrum(object):
 
             # Normalization is in cm**-2, so column density must be as well
             column_density = (field_data[continuum['field_name']] *
-                              field_data['dl']).in_units('cm**-2')
+                              field_data[('gas', 'dl')]).in_units('cm**-2')
             if (column_density == 0).all():
                 mylog.info("Not adding continuum %s: insufficient column density" % continuum['label'])
                 continue
@@ -709,7 +709,7 @@ class AbsorptionSpectrum(object):
         # and deposit the lines into the spectrum
         for store, line in parallel_objects(self.line_list, njobs=njobs,
                                             storage=self.line_observables_dict):
-            column_density = field_data[line['field_name']] * field_data['dl']
+            column_density = field_data[line['field_name']] * field_data[('gas', 'dl')]
             if (column_density < 0).any():
                 mylog.warning(
                     "Setting negative densities for field %s to 0! Bad!" % line['field_name'])
@@ -744,7 +744,7 @@ class AbsorptionSpectrum(object):
 
             # thermal broadening b parameter
             thermal_b =  np.sqrt((2 * boltzmann_constant_cgs *
-                                  field_data['temperature']) /
+                                  field_data[('gas', 'temperature')]) /
                                   line['atomic_mass'])
 
             # the actual thermal width of the lines

--- a/trident/ion_balance.py
+++ b/trident/ion_balance.py
@@ -687,7 +687,7 @@ def _ion_mass(field, data):
         return data[ftype,fraction_field_name] * \
           data[ftype, "mass"] * \
           data[ftype, metallicity_field]
-    
+
     if atom == 'H' or atom == 'He':
         mass_fraction = solar_abundance[atom] * data[ftype,fraction_field_name]
     else:

--- a/trident/light_ray.py
+++ b/trident/light_ray.py
@@ -601,7 +601,7 @@ class LightRay(CosmologySplice):
             # Get data for all subsegments in segment.
             for sub_segment in sub_segments:
                 mylog.info("Getting subsegment: %s to %s." %
-                           (list(sub_segment[0]), list(sub_segment[1])))
+                           (sub_segment[0], sub_segment[1]))
                 sub_ray = ds.ray(sub_segment[0], sub_segment[1])
                 for key, val in field_parameters.items():
                     sub_ray.set_field_parameter(key, val)

--- a/trident/line_database.py
+++ b/trident/line_database.py
@@ -93,6 +93,7 @@ class Line:
             ion_number = from_roman(ion_state)
             keyword = "%s_p%d" %  (element, (ion_number-1))
             field = "%s_number_density" % keyword
+            field = ("gas", field)
         self.field = field
 
     def __repr__(self):

--- a/trident/spectrum_generator.py
+++ b/trident/spectrum_generator.py
@@ -395,8 +395,7 @@ class SpectrumGenerator(AbsorptionSpectrum):
                 on_ion = my_ion.split("_")
                 # Add the field using ray's density, temperature, & metallicity
                 my_lev = int(on_ion[1][1:]) + 1
-                mylog.info("Creating %s from ray's density, "
-                           "temperature, metallicity." % (line.field[1]))
+                mylog.info("Creating %s from ray's fields." % (line.field[1]))
                 add_ion_number_density_field(on_ion[0], my_lev, ray,
                                  ionization_table=self.ionization_table)
 

--- a/trident/spectrum_generator.py
+++ b/trident/spectrum_generator.py
@@ -25,6 +25,8 @@ from yt.data_objects.static_output import \
 from yt.funcs import \
     mylog, \
     YTArray
+from yt.utilities.exceptions import \
+    YTFieldNotFound
 
 from trident.config import \
     ion_table_dir, \
@@ -386,14 +388,15 @@ class SpectrumGenerator(AbsorptionSpectrum):
             # otherwise we probably need to add the field to the dataset
             try:
                 ad._determine_fields(line.field)[0]
-            except BaseException:
+            except YTFieldNotFound:
+                fname = line.field[1] # grab field string from field name tuple
                 my_ion = \
-                  line.field[:line.field.find("number_density")]
+                  fname[:fname.find("number_density")]
                 on_ion = my_ion.split("_")
                 # Add the field using ray's density, temperature, & metallicity
                 my_lev = int(on_ion[1][1:]) + 1
                 mylog.info("Creating %s from ray's density, "
-                           "temperature, metallicity." % (line.field))
+                           "temperature, metallicity." % (line.field[1]))
                 add_ion_number_density_field(on_ion[0], my_lev, ray,
                                  ionization_table=self.ionization_table)
 


### PR DESCRIPTION
This PR goes through the codebase and addresses any of the deprecation warnings in yt4.  Mostly, it replaces string-based field calls with tuple-based field calls to get rid of all the annoying deprecation warnings yt now issues.  Testing locally against the answer test gold standard, this passes.