### PR TITLE
Changing apt-get command in circleci yaml to fix test fail.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,8 +32,9 @@ commands:
             git config --global user.name "C.I. Circle"
             # tag the tip so we can get back to it
             git tag tip
-            sudo apt-get --allow-releaseinfo-change update
-            sudo apt-get install -y texlive-latex-extra dvipng
+            sudo apt update
+            sudo apt upgrade
+            sudo apt install -y dvipng texlive-latex-extra
             if [ ! -d $HOME/venv ]; then
                 python3 -m venv $HOME/venv
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ commands:
             git config --global user.name "C.I. Circle"
             # tag the tip so we can get back to it
             git tag tip
-            sudo apt-get update
+            sudo apt-get --allow-releaseinfo-change update
             sudo apt-get install -y texlive-latex-extra dvipng
             if [ ! -d $HOME/venv ]; then
                 python3 -m venv $HOME/venv


### PR DESCRIPTION
Attempt to fix the failing tests.  Right now tests immediately fail with these errors (see: https://app.circleci.com/pipelines/github/trident-project/trident/597/workflows/f904426b-5394-47dc-81a5-7e93f0df0a04/jobs/2157):

```
Get:1 http://security.debian.org/debian-security buster/updates InRelease [65.4 kB]
Get:2 http://deb.debian.org/debian buster InRelease [122 kB]                   
Get:3 http://deb.debian.org/debian buster-updates InRelease [51.9 kB]          
Reading package lists... Done      
E: Repository 'http://security.debian.org/debian-security buster/updates InRelease' changed its 'Suite' value from 'stable' to 'oldstable'
N: This must be accepted explicitly before updates for this repository can be applied. See apt-secure(8) manpage for details.
N: Repository 'http://deb.debian.org/debian buster InRelease' changed its 'Version' value from '10.5' to '10.10'
E: Repository 'http://deb.debian.org/debian buster InRelease' changed its 'Suite' value from 'stable' to 'oldstable'
N: This must be accepted explicitly before updates for this repository can be applied. See apt-secure(8) manpage for details.
E: Repository 'http://deb.debian.org/debian buster-updates InRelease' changed its 'Suite' value from 'stable-updates' to 'oldstable-updates'
N: This must be accepted explicitly before updates for this repository can be applied. See apt-secure(8) manpage for details.

Exited with code exit status 100
CircleCI received exit code 100
```

See for solution:

https://stackoverflow.com/questions/68802802/repository-http-security-debian-org-debian-security-buster-updates-inrelease