### PR TITLE
Updating CI python versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -294,22 +294,22 @@ workflows:
    normal-tests:
      jobs:
        - tests:
-           name: "Python 3.6 tests with yt gold"
-           tag: "3.6.11"
+           name: "Python 3.7 tests with yt gold"
+           tag: "3.7.9"
 
        - tests:
-           name: "Python 3.8 tests with yt gold"
-           tag: "3.8.5"
+           name: "Python 3.9 tests with yt gold"
+           tag: "3.9.2"
 
        - tests:
-           name: "Python 3.8 tests with yt tip"
-           tag: "3.8.5"
+           name: "Python 3.9 tests with yt tip"
+           tag: "3.9.2"
            yttag: "YT_HEAD"
            coverage: 1
 
        - docs-test:
            name: "Test docs build"
-           tag: "3.8.5"
+           tag: "3.9.2"
 
    weekly:
      triggers:
@@ -322,14 +322,20 @@ workflows:
      jobs:
        - tests:
            name: "Python 3.7 tests with yt gold"
-           tag: "3.7.8"
+           tag: "3.7.9"
 
        - tests:
            name: "Python 3.8 tests with yt tip"
-           tag: "3.8.5"
+           tag: "3.8.8"
+           yttag: "YT_HEAD"
+           coverage: 0
+
+       - tests:
+           name: "Python 3.9 tests with yt tip"
+           tag: "3.9.2"
            yttag: "YT_HEAD"
            coverage: 0
 
        - docs-test:
            name: "Test docs build"
-           tag: "3.8.5"
+           tag: "3.9.2"

--- a/environment.yml
+++ b/environment.yml
@@ -30,10 +30,10 @@ dependencies:
     - python-dateutil==2.8.0
     - requests==2.22.0
     - scipy==1.0.1
-    - sphinx==3.2.1
+    - sphinx==4.2.0
     - sympy==1.4
     - traitlets==4.3.2
     - urllib3==1.25.3
     - wcwidth==0.1.7
-    - yt==3.5.1
+    - yt==4.0.1
     - yt-astro-analysis==1.0.0

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,4 +1,7 @@
 conda:
    file: environment.yml
 python:
-   setup_py_install: true
+   setup_py_install: false
+   pip_install: true
+   extra_requirements:
+        - dev


### PR DESCRIPTION
Starting to test with python 3.7 and 3.9.  No longer testing with 3.6 since yt+numpy+scipy are all stopping support for it.

Also, updating readthedocs info to hopefully fix the broken API docs.