### PR TITLE
Updating docs and fixing API docs on readthedocs

### DIFF
--- a/doc/source/absorption_spectrum.rst
+++ b/doc/source/absorption_spectrum.rst
@@ -8,7 +8,7 @@ see :ref:`spectrum-generation`.
 
 The :class:`~trident.absorption_spectrum.absorption_spectrum.AbsorptionSpectrum`
 is the internal class for creating absorption spectra in Trident from
-:class:`~trident.LightRay` objects. The
+:class:`~trident.light_ray.LightRay` objects. The
 :class:`~trident.absorption_spectrum.absorption_spectrum.AbsorptionSpectrum`
 and its workhorse method
 :meth:`~trident.absorption_spectrum.absorption_spectrum.AbsorptionSpectrum.make_spectrum`
@@ -19,13 +19,13 @@ listing all important lines.
 Method for Creating Absorption Spectra
 --------------------------------------
 
-Once a :class:`~trident.LightRay`
+Once a :class:`~trident.light_ray.LightRay`
 has been created traversing a dataset using the :ref:`light-ray-generator`,
 a series of arrays store the various fields of the gas parcels (represented
 as cells) intersected along the ray.
 :class:`~trident.absorption_spectrum.absorption_spectrum.AbsorptionSpectrum`
 steps through each element of the
-:class:`~trident.LightRay`'s
+:class:`~trident.light_ray.LightRay`'s
 arrays and calculates the column density for desired ion by multiplying its
 number density with the path length through the cell.  Using these column
 densities along with temperatures to calculate thermal broadening, voigt

--- a/doc/source/absorption_spectrum.rst
+++ b/doc/source/absorption_spectrum.rst
@@ -102,11 +102,11 @@ with the
 :meth:`~trident.absorption_spectrum.absorption_spectrum.AbsorptionSpectrum.add_continuum`
 function.  Like adding lines, you must specify details like the wavelength
 and the field in the dataset and LightRay that is tied to this feature.
-The wavelength refers to the location at which the continuum begins to be 
-applied to the dataset, and as it moves to lower wavelength values, the 
-optical depth value decreases according to the defined power law.  The 
+The wavelength refers to the location at which the continuum begins to be
+applied to the dataset, and as it moves to lower wavelength values, the
+optical depth value decreases according to the defined power law.  The
 normalization value is the column density of the linked field which results
-in an optical depth of 1 at the defined wavelength.  Below, we add the hydrogen 
+in an optical depth of 1 at the defined wavelength.  Below, we add the hydrogen
 Lyman continuum.
 
 .. code-block:: python

--- a/doc/source/absorption_spectrum_fit.rst
+++ b/doc/source/absorption_spectrum_fit.rst
@@ -3,11 +3,8 @@
 Fitting Absorption Spectra
 ==========================
 
-.. sectionauthor:: Hilary Egan <hilary.egan@colorado.edu>
-
 This tool can be used to fit absorption spectra, particularly those
-generated using the
-:class:`~trident.absorption_spectrum.absorption_spectrum.AbsorptionSpectrum`.
+generated using Trident.
 For more details on its uses and implementation please see (`Egan et al. (2013)
 <http://arxiv.org/abs/1307.2244>`_). If you find this tool useful we
 encourage you to cite accordingly.
@@ -16,7 +13,7 @@ Loading an Absorption Spectrum
 ------------------------------
 
 To load an absorption spectrum created by
-:class:`~trident.absorption_spectrum.absorption_spectrum.AbsorptionSpectrum`,
+:class:`~trident.spectrum_generator.SpectrumGenerator`,
 specify the output file name. It is advisable to use either an .h5
 or .fits file, rather than an ascii file to save the spectrum as rounding
 errors produced in saving to a ascii file will negatively impact fit quality.
@@ -131,8 +128,6 @@ a group for the corresponding N, b, z, and group# values.
 
 Procedure for Generating Fits
 -----------------------------
-
-.. sectionauthor:: Hilary Egan <hilary.egan@colorado.edu>
 
 To generate a fit for a spectrum
 :func:`~trident.absorption_spectrum.absorption_spectrum_fit.generate_total_fit`

--- a/doc/source/advanced_spectra.rst
+++ b/doc/source/advanced_spectra.rst
@@ -3,19 +3,19 @@
 Advanced Spectrum Generation
 ============================
 
-In addition to generating a basic spectrum as demonstrated in 
-the :ref:`annotated example <annotated-example>`, the user can also 
+In addition to generating a basic spectrum as demonstrated in
+the :ref:`annotated example <annotated-example>`, the user can also
 customize the generated spectrum in a variety of ways.  One can choose which
 spectral lines to deposit or choose different settings for the characteristics
-of the spectrograph, and more.  The following code goes through the process of 
+of the spectrograph, and more.  The following code goes through the process of
 setting these properties and shows what impact it has on resulting spectra.
 
 For this demonstation, we'll be using a light ray passing through a very dense
-disk of gas, taken from the initial output from the AGORA isolated box 
+disk of gas, taken from the initial output from the AGORA isolated box
 simulation using ART-II in `Kim et al. (2016)
 <http://adsabs.harvard.edu/abs/2016ApJ...833..202K>`_.
-If you'd like to try to reproduce the spectra included below you can get 
-the :class:`~trident.LightRay` file from the Trident sample data using the 
+If you'd like to try to reproduce the spectra included below you can get
+the :class:`~trident.LightRay` file from the Trident sample data using the
 command:
 
 .. highlight:: none
@@ -40,11 +40,11 @@ instruments that come with Trident.  To list the presets and their respective
 values, use this command::
 
     print(trident.valid_instruments)
-    
-Currently, we have `three settings for the Cosmic Origins Spectrograph 
+
+Currently, we have `three settings for the Cosmic Origins Spectrograph
 <http://www.stsci.edu/hst/cos/design/gratings/>`_ available:
 ``COS-G130M``, ``COS-G140L``, and ``COS-G160M``, but we plan to add more
-instruments soon.  To use one of them, we just use the name string in the 
+instruments soon.  To use one of them, we just use the name string in the
 SpectrumGenerator class::
 
    sg = trident.SpectrumGenerator('COS-G130M')
@@ -54,32 +54,32 @@ from 1150 angstroms to 1250 angstroms with a resolution of 0.01 angstroms::
 
    sg = trident.SpectrumGenerator(lambda_min=1150, lambda_max=1250, dlambda=0.01)
 
-From here, we can pass the ray to the :class:`~trident.SpectrumGenerator` object 
-to use in the construction of a spectrum. 
+From here, we can pass the ray to the :class:`~trident.SpectrumGenerator` object
+to use in the construction of a spectrum.
 
 Choosing what absorption features to include
 --------------------------------------------
 
-There is a :class:`~trident.LineDatabase` class that controls which spectral 
+There is a :class:`~trident.LineDatabase` class that controls which spectral
 lines you can add to your spectrum.  Trident provides you with a default
-:class:`~trident.LineDatabase` with 213 spectral lines commonly used in CGM 
-and IGM studies, but you can create your own :class:`~trident.LineDatabase` 
-with different lines.  To see a list of all the lines included in the default 
+:class:`~trident.LineDatabase` with 213 spectral lines commonly used in CGM
+and IGM studies, but you can create your own :class:`~trident.LineDatabase`
+with different lines.  To see a list of all the lines included in the default
 line list::
 
     ldb = trident.LineDatabase('lines.txt')
     print(ldb)
 
-which is reading lines from the 'lines.txt' file present in the 
+which is reading lines from the 'lines.txt' file present in the
 data directory (see :ref:`where is Trident installed? <where-installed>`)
-We can specify any subset of these spectral lines to use when creating the 
-spectrum from our master line list.  So if you're interested in just looking 
-at neutral hydrogen lines in your spectrum, you can see what lines will be 
+We can specify any subset of these spectral lines to use when creating the
+spectrum from our master line list.  So if you're interested in just looking
+at neutral hydrogen lines in your spectrum, you can see what lines will be
 included with the command::
 
     print(ldb.parse_subset('H I'))
 
-As a first pass, we'll create a spectrum that just include lines produced 
+As a first pass, we'll create a spectrum that just include lines produced
 by hydrogen::
 
     sg.make_spectrum(ray, lines=['H'])
@@ -89,7 +89,7 @@ The resulting spectrum contains a nice, big Lyman-alpha feature.
 
 .. image:: trident-docs-images/spectra/spec_H.png
 
-If, instead, we want to shows the lines that would be in our spectral range 
+If, instead, we want to shows the lines that would be in our spectral range
 due to carbon, nitrogen, and oxygen, we can do the following::
 
     sg.make_spectrum(ray, lines=['C', 'N', 'O'])
@@ -99,7 +99,7 @@ And now we have:
 
 .. image:: trident-docs-images/spectra/spec_CNO.png
 
-We can see how these two spectra combined when we include all of the same 
+We can see how these two spectra combined when we include all of the same
 lines::
 
     sg.make_spectrum(ray, lines=['H', 'C', 'N', 'O'])
@@ -109,8 +109,8 @@ which gives:
 
 .. image:: trident-docs-images/spectra/spec_HCNO.png
 
-We can get even more specific, by generating a spectrum that only contains 
-lines due to a single ion species.  For example, we might just want the 
+We can get even more specific, by generating a spectrum that only contains
+lines due to a single ion species.  For example, we might just want the
 lines from four-times-ionized nitrogen, N V::
 
     sg.make_spectrum(ray, lines=['N V'])
@@ -129,7 +129,7 @@ And we end up with:
 
 .. image:: trident-docs-images/spectra/spec_CI_1193_1194.png
 
-Or we can just include all of the available lines in our 
+Or we can just include all of the available lines in our
 :class:`~trident.LineDatabase` with::
 
     sg.make_spectrum(ray, lines='all')
@@ -139,7 +139,7 @@ Giving us:
 
 .. image:: trident-docs-images/spectra/spec_all.png
 
-To understand how to further customize your spectra, look at the documentation 
+To understand how to further customize your spectra, look at the documentation
 for the :class:`~trident.SpectrumGenerator` and :class:`~trident.LineDatabase`
 classes and other :ref:`API <api-reference>` documentation.
 

--- a/doc/source/advanced_spectra.rst
+++ b/doc/source/advanced_spectra.rst
@@ -15,7 +15,7 @@ disk of gas, taken from the initial output from the AGORA isolated box
 simulation using ART-II in `Kim et al. (2016)
 <http://adsabs.harvard.edu/abs/2016ApJ...833..202K>`_.
 If you'd like to try to reproduce the spectra included below you can get
-the :class:`~trident.LightRay` file from the Trident sample data using the
+the :class:`~trident.light_ray.LightRay` file from the Trident sample data using the
 command:
 
 .. highlight:: none
@@ -45,7 +45,7 @@ Currently, we have `three settings for the Cosmic Origins Spectrograph
 <http://www.stsci.edu/hst/cos/design/gratings/>`_ available:
 ``COS-G130M``, ``COS-G140L``, and ``COS-G160M``, but we plan to add more
 instruments soon.  To use one of them, we just use the name string in the
-SpectrumGenerator class::
+:class:`~trident.spectrum_generator.SpectrumGenerator` class::
 
    sg = trident.SpectrumGenerator('COS-G130M')
 
@@ -54,18 +54,19 @@ from 1150 angstroms to 1250 angstroms with a resolution of 0.01 angstroms::
 
    sg = trident.SpectrumGenerator(lambda_min=1150, lambda_max=1250, dlambda=0.01)
 
-From here, we can pass the ray to the :class:`~trident.SpectrumGenerator` object
-to use in the construction of a spectrum.
+From here, we can pass the ray to the
+:class:`~trident.spectrum_generator.SpectrumGenerator` object to use in the
+construction of a spectrum.
 
 Choosing what absorption features to include
 --------------------------------------------
 
-There is a :class:`~trident.LineDatabase` class that controls which spectral
-lines you can add to your spectrum.  Trident provides you with a default
-:class:`~trident.LineDatabase` with 213 spectral lines commonly used in CGM
-and IGM studies, but you can create your own :class:`~trident.LineDatabase`
-with different lines.  To see a list of all the lines included in the default
-line list::
+There is a :class:`~trident.line_database.LineDatabase` class that controls which
+spectral lines you can add to your spectrum.  Trident provides you with a default
+:class:`~trident.line_database.LineDatabase` with 213 spectral lines commonly used
+in CGM and IGM studies, but you can create your own
+:class:`~trident.line_database.LineDatabase` with different lines.  To see a list of
+all the lines included in the default line list::
 
     ldb = trident.LineDatabase('lines.txt')
     print(ldb)
@@ -130,7 +131,7 @@ And we end up with:
 .. image:: trident-docs-images/spectra/spec_CI_1193_1194.png
 
 Or we can just include all of the available lines in our
-:class:`~trident.LineDatabase` with::
+:class:`~trident.line_database.LineDatabase` with::
 
     sg.make_spectrum(ray, lines='all')
     sg.plot_spectrum('spec_all.png')
@@ -140,16 +141,17 @@ Giving us:
 .. image:: trident-docs-images/spectra/spec_all.png
 
 To understand how to further customize your spectra, look at the documentation
-for the :class:`~trident.SpectrumGenerator` and :class:`~trident.LineDatabase`
-classes and other :ref:`API <api-reference>` documentation.
+for the :class:`~trident.spectrum_generator.SpectrumGenerator` and
+:class:`~trident.line_database.LineDatabase` classes and other
+:ref:`API <api-reference>` documentation.
 
 Setting Wavelength Bounds Automatically
 ---------------------------------------
 
 If you are interested in creating a spectrum that contains all possible
 absorption features for a given set of lines, the
-:class:`~trident.SpectrumGenerator` can be configured to automatically
-enlarge the wavelength window until all absorption is captured. This is
+:class:`~trident.spectrum_generator.SpectrumGenerator` can be configured to
+automatically enlarge the wavelength window until all absorption is captured. This is
 done by setting the ``lambda_min`` and ``lambda_max`` keywords to 'auto'
 and specifying a bin size with the ``dlambda`` keyword::
 
@@ -171,7 +173,8 @@ Making Spectra in Velocity Space
 Trident can be configured to create spectra in velocity space instead of
 wavelength space where velocity corresponds to the velocity offset from
 the rest wavelength of a given line. This can be done by providing the
-keyword ``bin_space='velocity'`` to the :class:`~trident.SpectrumGenerator`::
+keyword ``bin_space='velocity'`` to the
+:class:`~trident.spectrum_generator.SpectrumGenerator`::
 
     sg = trident.SpectrumGenerator(lambda_min='auto', lambda_max='auto',
                                    dlambda=1., bin_space='velocity')

--- a/doc/source/annotated_example.rst
+++ b/doc/source/annotated_example.rst
@@ -65,26 +65,13 @@ We can now generate the light ray using the :class:`~trident.make_simple_ray`
 function by passing the dataset and the trajectory endpoints to it as well
 as telling trident to save the resulting ray dataset to an HDF5 file. We
 explicitly instruct trident to pull all necessary fields from the dataset
-in order to be able to add the lines from our ``line_list``.
-Lastly, we set the ``ftype`` keyword as the field type of the fields
-where Trident will look to find density, temperature, and metallicity for
-building the required ion fields::
+in order to be able to add the lines from our ``line_list``::
 
     ray = trident.make_simple_ray(ds,
                                   start_position=ray_start,
                                   end_position=ray_end,
                                   data_filename="ray.h5",
-                                  lines=line_list,
-                                  ftype='gas')
-
-.. warning::
-    It is imperative that you set the ``ftype`` keyword properly for your dataset.
-    An ``ftype`` of 'gas' is adequate for grid-based codes, but not particle.
-    Particle-based datasets must set ``ftype`` to the field type
-    of their gas particles (e.g. 'PartType0') to assure that Trident builds 
-    the ion fields on the particles themselves before smoothing these fields 
-    to the grid.  By not setting this correctly, you risk bad ion values by
-    building from smoothed gas fields.
+                                  lines=line_list)
 
 Overplotting a LightRay's Trajectory on a Projection
 ----------------------------------------------------
@@ -172,7 +159,6 @@ allowing the user to specify the same sort of line list as before:::
   fn = 'enzo_cosmology_plus/AMRCosmology.enzo'
   ray = trident.make_compound_ray(fn, simulation_type='Enzo',
                                   near_redshift=0.0, far_redshift=0.1,
-				  ftype='gas',
                                   lines=line_list)
 
 In this example, we've created a ray from an Enzo simulation (the same

--- a/doc/source/annotated_example.rst
+++ b/doc/source/annotated_example.rst
@@ -61,7 +61,7 @@ and magnesium lines to the resulting spectrum from the dataset::
 
     line_list = ['H', 'C', 'N', 'O', 'Mg']
 
-We can now generate the light ray using the :class:`~trident.ray_generator.make_simple_ray`
+We can now generate the light ray using the :func:`~trident.ray_generator.make_simple_ray`
 function by passing the dataset and the trajectory endpoints to it as well
 as telling trident to save the resulting ray dataset to an HDF5 file. We
 explicitly instruct trident to pull all necessary fields from the dataset
@@ -180,8 +180,8 @@ inherently unphysical since large scale structure evolves with cosmic
 time, Trident allows the user to create a ray that samples multiple
 datasets from different redshifts to produce a much longer ray that is
 continuous in redshift space.  This is done by using the
-:class:`~trident.ray_generator.make_compound_ray` function.  This function is
-similar to the previously mentioned :class:`~trident.ray_generator.make_simple_ray`
+:func:`~trident.ray_generator.make_compound_ray` function.  This function is
+similar to the previously mentioned :func:`~trident.ray_generator.make_simple_ray`
 function, but instead of accepting an individual dataset, it takes a
 simulation parameter file, the associated simulation type, and the
 desired range in redshift to be probed by the ray, while still
@@ -204,7 +204,7 @@ the `yt_astro_analysis documentation
 <https://yt-astro-analysis.readthedocs.io/en/latest/planning_cosmology_simulations.html>`__.
 
 We encourage you to look at the detailed documentation for
-:class:`~trident.ray_generator.make_compound_ray` in the :ref:`api-reference`
+:func:`~trident.ray_generator.make_compound_ray` in the :ref:`api-reference`
 section to understand how to control how the ray itself is constructed
 from the available data.
 

--- a/doc/source/annotated_example.rst
+++ b/doc/source/annotated_example.rst
@@ -9,7 +9,7 @@ This section will walk you through the steps necessary to
 produce a synthetic spectrum based on simulation data and to view its path
 through the parent dataset.  The following example, `available in the source
 code itself 
-<https://github.com/trident-project/trident/blob/master/examples/working_script.py>`_,
+<https://github.com/trident-project/trident/blob/main/examples/working_script.py>`_,
 can be applied to datasets from any of the different simulation codes that 
 `Trident and yt support <http://yt-project.org/docs/dev/reference/code_support.html#code-support>`_, 
 although it may require some tweaking of parameters for optimal performance. 

--- a/doc/source/annotated_example.rst
+++ b/doc/source/annotated_example.rst
@@ -86,7 +86,9 @@ present in the original dataset:
     * ``('gas', 'redshift_eff')`` Effective redshift (combined cosmological and Doppler)
 
 Like any dataset, you can see what fields are present on the ray by examining its
-``derived_field_list`` (``print(ds.derived_field_list``).
+``derived_field_list`` (e.g., ``print(ds.derived_field_list``).  If you want more ions
+present on this ray than are currently shown, you can add them with
+:class:`~trident.add_ion_fields` (see: :ref:`ion-balance`).
 
 This ``ray`` object is also saved to disk as an HDF5 file, which can later be loaded
 into ``yt`` as a stand-alone dataset (e.g., ``ds = yt.load('ray.h5')``).
@@ -104,6 +106,17 @@ any volumentric plot, including slices, and off-axis plots::
     p.save('projection.png')
 
 .. image:: trident-docs-images/annotated_example/projection.png
+
+Calculating Column Densities
+----------------------------
+
+Perhaps we wish to know the total column density of a particular ion present along
+this :class:`~trident.LightRay`. This can easily be done by multiplying the desired
+ion number density field by the pathlength field, ``dl``, to yield an array of 
+column densities for each resolution element, and then summing them together::
+
+    column_density_HI = ray.r[('gas', 'H_p0_number_density')] * ray.r[('gas', 'dl')]
+    print('HI Column Density = %g' % column_density_HI.sum())
 
 .. _spectrum-generation:
 

--- a/doc/source/annotated_example.rst
+++ b/doc/source/annotated_example.rst
@@ -211,6 +211,7 @@ from the available data.
 .. note::
 
         The compound ray functionality has only been implemented for the
-        Enzo and Gadget simulation codes.  If you would like to help us
+        Enzo and Gadget simulation codes (and Gadget's derivatives including
+        Gizmo and AREPO).  If you would like to help us
         implement this functionality for your simulation code, please contact
         us about this on the mailing list.

--- a/doc/source/annotated_example.rst
+++ b/doc/source/annotated_example.rst
@@ -3,25 +3,25 @@
 Annotated Example
 =================
 
-The best way to get a feel for what Trident can do is to go through an 
-annotated example of its use.  
-This section will walk you through the steps necessary to 
+The best way to get a feel for what Trident can do is to go through an
+annotated example of its use.
+This section will walk you through the steps necessary to
 produce a synthetic spectrum based on simulation data and to view its path
 through the parent dataset.  The following example, `available in the source
-code itself 
+code itself
 <https://github.com/trident-project/trident/blob/main/examples/working_script.py>`_,
-can be applied to datasets from any of the different simulation codes that 
-`Trident and yt support <http://yt-project.org/docs/dev/reference/code_support.html#code-support>`_, 
-although it may require some tweaking of parameters for optimal performance. 
-If you want to recreate the following analysis with the 
+can be applied to datasets from any of the different simulation codes that
+`Trident and yt support <http://yt-project.org/docs/dev/reference/code_support.html#code-support>`_,
+although it may require some tweaking of parameters for optimal performance.
+If you want to recreate the following analysis with the
 exact dataset used, it can be downloaded `here <http://yt-project.org/data/>`_.
 
-The basic process for generating a spectrum and overplotting a sightline's 
+The basic process for generating a spectrum and overplotting a sightline's
 trajectory through the dataset goes in three steps:
 
-    1. Generate a :class:`~trident.LightRay` from the simulation data 
+    1. Generate a :class:`~trident.LightRay` from the simulation data
        representing a sightline through the data.
-    2. Define the desired spectrum features and use the :class:`~trident.LightRay` to 
+    2. Define the desired spectrum features and use the :class:`~trident.LightRay` to
        create a corresponding synthetic spectrum.
     3. Create a projected image and overplot the path of the :class:`~trident.LightRay`.
 
@@ -33,10 +33,10 @@ Simple LightRay Generation
 A :class:`~trident.LightRay` is a 1D object representing the path a ray of
 light takes through a simulation volume on its way from some bright background
 object to the observer.  It records all of the gas fields it intersects along
-the way for use in construction of a spectrum.  
+the way for use in construction of a spectrum.
 
-In order to generate a :class:`~trident.LightRay` from your data, you need to first make sure 
-that you've imported both the yt and Trident packages, and 
+In order to generate a :class:`~trident.LightRay` from your data, you need to first make sure
+that you've imported both the yt and Trident packages, and
 specify the filename of the dataset from which to extract the light ray::
 
    import yt
@@ -45,7 +45,7 @@ specify the filename of the dataset from which to extract the light ray::
 
 We need to decide the trajectory that the :class:`~trident.LightRay` will take
 through our simulation volume.  This arbitrary trajectory is specified with
-coordinates in code length units (e.g. [x_start, y_start, z_start] to 
+coordinates in code length units (e.g. [x_start, y_start, z_start] to
 [x_end, y_end, z_end]). Probably the simplest trajectory is cutting
 diagonally from the origin of the simulation volume to its outermost corner
 using the yt ``domain_left_edge`` and ``domain_right_edge`` attributes.  Here
@@ -74,9 +74,9 @@ in order to be able to add the lines from our ``line_list``::
                                   lines=line_list)
 
 The resulting ``ray`` is a :class:`~trident.LightRay` object, consisting of a series
-of arrays representing the different fields it probes in the original dataset along 
+of arrays representing the different fields it probes in the original dataset along
 its length.  Each element in the arrays represents a different resolution element
-along the path of the ray.  The ray also possesses some special fields not originally 
+along the path of the ray.  The ray also possesses some special fields not originally
 present in the original dataset:
 
     * ``('gas', l')`` Location along the LightRay length from 0 to 1.
@@ -96,7 +96,7 @@ into ``yt`` as a stand-alone dataset (e.g., ``ds = yt.load('ray.h5')``).
 Overplotting a LightRay's Trajectory on a Projection
 ----------------------------------------------------
 
-Here we create a projection of the density field along the x axis of the 
+Here we create a projection of the density field along the x axis of the
 dataset, and then overplot the path the :class:`~trident.LightRay` takes through the simulation,
 before saving it to disk.  The ``annotate_ray()`` operation should work for
 any volumentric plot, including slices, and off-axis plots::
@@ -112,7 +112,7 @@ Calculating Column Densities
 
 Perhaps we wish to know the total column density of a particular ion present along
 this :class:`~trident.LightRay`. This can easily be done by multiplying the desired
-ion number density field by the pathlength field, ``dl``, to yield an array of 
+ion number density field by the pathlength field, ``dl``, to yield an array of
 column densities for each resolution element, and then summing them together::
 
     column_density_HI = ray.r[('gas', 'H_p0_number_density')] * ray.r[('gas', 'dl')]
@@ -126,14 +126,14 @@ Spectrum Generation
 Now that we have our :class:`~trident.LightRay` we can use it to generate a spectrum.
 To create a spectrum, we need to make a :class:`~trident.SpectrumGenerator`
 object defining our desired wavelength range and bin size.  You can do this
-by manually setting these features, or just using one of the presets for 
+by manually setting these features, or just using one of the presets for
 an instrument.  Currently, we have three pre-defined instruments, the G130M,
 G160M, and G140L observing modes for the Cosmic Origins Spectrograph aboard
 the Hubble Space Telescope: ``COS-G130M``, ``COS-G160M``, and ``COS-G140L``.
 Notably, instrument ``COS`` aliases to ``COS-G130M``.
 
-We then use this :class:`~trident.SpectrumGenerator` object to make a *raw* 
-spectrum according to the intersecting fields it encountered in the 
+We then use this :class:`~trident.SpectrumGenerator` object to make a *raw*
+spectrum according to the intersecting fields it encountered in the
 corresponding :class:`~trident.LightRay`.  We save this spectrum to disk, and
 plot it::
 
@@ -145,7 +145,7 @@ plot it::
 .. image:: trident-docs-images/annotated_example/spec_raw.png
    :width: 700
 
-From here we can do some post-processing to the spectrum to include 
+From here we can do some post-processing to the spectrum to include
 additional features that would be present in an actual observed spectrum.
 We add a background quasar spectrum, a Milky Way foreground, apply the
 COS line spread function, and add gaussian noise with SNR=30::
@@ -194,7 +194,7 @@ allowing the user to specify the same sort of line list as before:::
 
 In this example, we've created a ray from an Enzo simulation (the same
 one used above) that goes from z = 0 to z = 0.1. This ray can now be
-used to generate spectra in the exact same ways as before. 
+used to generate spectra in the exact same ways as before.
 
 Obviously, there need to be sufficient simulation outputs over the desired
 redshift range of the compound ray in order to have continuous sampling.
@@ -211,6 +211,6 @@ from the available data.
 .. note::
 
         The compound ray functionality has only been implemented for the
-        Enzo and Gadget simulation codes.  If you would like to help us 
-        implement this functionality for your simulation code, please contact 
+        Enzo and Gadget simulation codes.  If you would like to help us
+        implement this functionality for your simulation code, please contact
         us about this on the mailing list.

--- a/doc/source/annotated_example.rst
+++ b/doc/source/annotated_example.rst
@@ -73,6 +73,24 @@ in order to be able to add the lines from our ``line_list``::
                                   data_filename="ray.h5",
                                   lines=line_list)
 
+The resulting ``ray`` is a :class:`~trident.LightRay` object, consisting of a series
+of arrays representing the different fields it probes in the original dataset along 
+its length.  Each element in the arrays represents a different resolution element
+along the path of the ray.  The ray also possesses some special fields not originally 
+present in the original dataset:
+
+    * ``('gas', l')`` Location along the LightRay length from 0 to 1.
+    * ``('gas', 'dl')`` Pathlength of resolution element (not a *true* pathlength for particle-based codes)
+    * ``('gas', 'redshift')`` Cosmological redshift of resolution element
+    * ``('gas', 'redshift_dopp')`` Doppler redshift of resolution element
+    * ``('gas', 'redshift_eff')`` Effective redshift (combined cosmological and Doppler)
+
+Like any dataset, you can see what fields are present on the ray by examining its
+``derived_field_list`` (``print(ds.derived_field_list``).
+
+This ``ray`` object is also saved to disk as an HDF5 file, which can later be loaded
+into ``yt`` as a stand-alone dataset (e.g., ``ds = yt.load('ray.h5')``).
+
 Overplotting a LightRay's Trajectory on a Projection
 ----------------------------------------------------
 

--- a/doc/source/annotated_example.rst
+++ b/doc/source/annotated_example.rst
@@ -19,23 +19,23 @@ exact dataset used, it can be downloaded `here <http://yt-project.org/data/>`_.
 The basic process for generating a spectrum and overplotting a sightline's
 trajectory through the dataset goes in three steps:
 
-    1. Generate a :class:`~trident.LightRay` from the simulation data
+    1. Generate a :class:`~trident.light_ray.LightRay` from the simulation data
        representing a sightline through the data.
-    2. Define the desired spectrum features and use the :class:`~trident.LightRay` to
+    2. Define the desired spectrum features and use the :class:`~trident.light_ray.LightRay` to
        create a corresponding synthetic spectrum.
-    3. Create a projected image and overplot the path of the :class:`~trident.LightRay`.
+    3. Create a projected image and overplot the path of the :class:`~trident.light_ray.LightRay`.
 
 .. _simple-ray:
 
 Simple LightRay Generation
 --------------------------
 
-A :class:`~trident.LightRay` is a 1D object representing the path a ray of
+A :class:`~trident.light_ray.LightRay` is a 1D object representing the path a ray of
 light takes through a simulation volume on its way from some bright background
 object to the observer.  It records all of the gas fields it intersects along
 the way for use in construction of a spectrum.
 
-In order to generate a :class:`~trident.LightRay` from your data, you need to first make sure
+In order to generate a :class:`~trident.light_ray.LightRay` from your data, you need to first make sure
 that you've imported both the yt and Trident packages, and
 specify the filename of the dataset from which to extract the light ray::
 
@@ -43,7 +43,7 @@ specify the filename of the dataset from which to extract the light ray::
    import trident
    fn = 'enzo_cosmology_plus/RD0009/RD0009'
 
-We need to decide the trajectory that the :class:`~trident.LightRay` will take
+We need to decide the trajectory that the :class:`~trident.light_ray.LightRay` will take
 through our simulation volume.  This arbitrary trajectory is specified with
 coordinates in code length units (e.g. [x_start, y_start, z_start] to
 [x_end, y_end, z_end]). Probably the simplest trajectory is cutting
@@ -61,7 +61,7 @@ and magnesium lines to the resulting spectrum from the dataset::
 
     line_list = ['H', 'C', 'N', 'O', 'Mg']
 
-We can now generate the light ray using the :class:`~trident.make_simple_ray`
+We can now generate the light ray using the :class:`~trident.ray_generator.make_simple_ray`
 function by passing the dataset and the trajectory endpoints to it as well
 as telling trident to save the resulting ray dataset to an HDF5 file. We
 explicitly instruct trident to pull all necessary fields from the dataset
@@ -73,7 +73,7 @@ in order to be able to add the lines from our ``line_list``::
                                   data_filename="ray.h5",
                                   lines=line_list)
 
-The resulting ``ray`` is a :class:`~trident.LightRay` object, consisting of a series
+The resulting ``ray`` is a :class:`~trident.light_ray.LightRay` object, consisting of a series
 of arrays representing the different fields it probes in the original dataset along
 its length.  Each element in the arrays represents a different resolution element
 along the path of the ray.  The ray also possesses some special fields not originally
@@ -88,7 +88,7 @@ present in the original dataset:
 Like any dataset, you can see what fields are present on the ray by examining its
 ``derived_field_list`` (e.g., ``print(ds.derived_field_list``).  If you want more ions
 present on this ray than are currently shown, you can add them with
-:class:`~trident.add_ion_fields` (see: :ref:`ion-balance`).
+:class:`~trident.ion_balance.add_ion_fields` (see: :ref:`ion-balance`).
 
 This ``ray`` object is also saved to disk as an HDF5 file, which can later be loaded
 into ``yt`` as a stand-alone dataset (e.g., ``ds = yt.load('ray.h5')``).
@@ -97,7 +97,7 @@ Overplotting a LightRay's Trajectory on a Projection
 ----------------------------------------------------
 
 Here we create a projection of the density field along the x axis of the
-dataset, and then overplot the path the :class:`~trident.LightRay` takes through the simulation,
+dataset, and then overplot the path the :class:`~trident.light_ray.LightRay` takes through the simulation,
 before saving it to disk.  The ``annotate_ray()`` operation should work for
 any volumentric plot, including slices, and off-axis plots::
 
@@ -111,7 +111,7 @@ Calculating Column Densities
 ----------------------------
 
 Perhaps we wish to know the total column density of a particular ion present along
-this :class:`~trident.LightRay`. This can easily be done by multiplying the desired
+this :class:`~trident.light_ray.LightRay`. This can easily be done by multiplying the desired
 ion number density field by the pathlength field, ``dl``, to yield an array of
 column densities for each resolution element, and then summing them together::
 
@@ -123,8 +123,8 @@ column densities for each resolution element, and then summing them together::
 Spectrum Generation
 -------------------
 
-Now that we have our :class:`~trident.LightRay` we can use it to generate a spectrum.
-To create a spectrum, we need to make a :class:`~trident.SpectrumGenerator`
+Now that we have our :class:`~trident.light_ray.LightRay` we can use it to generate a spectrum.
+To create a spectrum, we need to make a :class:`~trident.spectrum_generator.SpectrumGenerator`
 object defining our desired wavelength range and bin size.  You can do this
 by manually setting these features, or just using one of the presets for
 an instrument.  Currently, we have three pre-defined instruments, the G130M,
@@ -132,9 +132,9 @@ G160M, and G140L observing modes for the Cosmic Origins Spectrograph aboard
 the Hubble Space Telescope: ``COS-G130M``, ``COS-G160M``, and ``COS-G140L``.
 Notably, instrument ``COS`` aliases to ``COS-G130M``.
 
-We then use this :class:`~trident.SpectrumGenerator` object to make a *raw*
+We then use this :class:`~trident.spectrum_generator.SpectrumGenerator` object to make a *raw*
 spectrum according to the intersecting fields it encountered in the
-corresponding :class:`~trident.LightRay`.  We save this spectrum to disk, and
+corresponding :class:`~trident.light_ray.LightRay`.  We save this spectrum to disk, and
 plot it::
 
     sg = trident.SpectrumGenerator('COS-G130M')
@@ -180,8 +180,8 @@ inherently unphysical since large scale structure evolves with cosmic
 time, Trident allows the user to create a ray that samples multiple
 datasets from different redshifts to produce a much longer ray that is
 continuous in redshift space.  This is done by using the
-:class:`~trident.make_compound_ray` function.  This function is
-similar to the previously mentioned :class:`~trident.make_simple_ray`
+:class:`~trident.ray_generator.make_compound_ray` function.  This function is
+similar to the previously mentioned :class:`~trident.ray_generator.make_simple_ray`
 function, but instead of accepting an individual dataset, it takes a
 simulation parameter file, the associated simulation type, and the
 desired range in redshift to be probed by the ray, while still
@@ -204,7 +204,7 @@ the `yt_astro_analysis documentation
 <https://yt-astro-analysis.readthedocs.io/en/latest/planning_cosmology_simulations.html>`__.
 
 We encourage you to look at the detailed documentation for
-:class:`~trident.make_compound_ray` in the :ref:`api-reference`
+:class:`~trident.ray_generator.make_compound_ray` in the :ref:`api-reference`
 section to understand how to control how the ray itself is constructed
 from the available data.
 

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -8,7 +8,7 @@ This document summarizes changes to the codebase with time for Trident.
 Contributors
 ------------
 
-The `CREDITS file <https://github.com/trident-project/trident/blob/master/CREDITS>`_
+The `CREDITS file <https://github.com/trident-project/trident/blob/main/CREDITS>`_
 has an updated list of contributors to the codebase.
 
 

--- a/doc/source/citation.rst
+++ b/doc/source/citation.rst
@@ -3,8 +3,8 @@
 Citation
 ========
 
-If you use Trident for a research application, please cite the 
-`Trident method paper <http://adsabs.harvard.edu/abs/2017ApJ...847...59H>`_ 
+If you use Trident for a research application, please cite the
+`Trident method paper <http://adsabs.harvard.edu/abs/2017ApJ...847...59H>`_
 in your work with the bibtex entry below::
 
     @ARTICLE{2017ApJ...847...59H,

--- a/doc/source/faq.rst
+++ b/doc/source/faq.rst
@@ -65,6 +65,12 @@ on derived fields
             units="Zsun",
         )
 
+What functions are available and what is their syntax?
+------------------------------------------------------
+
+Go see the full documentation for all of our available classes and functions in the
+:ref:`API Documentation <api-reference>`.
+
 What version of Trident am I running?
 -------------------------------------
 

--- a/doc/source/faq.rst
+++ b/doc/source/faq.rst
@@ -9,10 +9,10 @@ Why don't I have any absorption features in my spectrum?
 --------------------------------------------------------
 
 There are many reasons you might not have any absorption features in your
-spectrum, but we'll cover a few of the basic explanations here.  
+spectrum, but we'll cover a few of the basic explanations here.
 
  #. Your absorbers are in a different part of the spectrum than you're plotting.
-    Make sure you are plotting the wavelength range where you expect to see the 
+    Make sure you are plotting the wavelength range where you expect to see the
     absorption by taking into account the wavelength of your absorption features
     coupled with the redshift of your dataset: :math:`\lambda_{obs} = (1 + z) \lambda_{rest}`
     To see the wavelength of specific ionic transitions, see the line list in:
@@ -21,7 +21,7 @@ spectrum, but we'll cover a few of the basic explanations here.
  #. Your sightlines do not have sufficient column densities of the desired
     ions to actually make an absorption feature.  Look at the total column
     density of your desired ions in your sightline by multiplying the
-    density times the path length and summing it all up.  Here is an 
+    density times the path length and summing it all up.  Here is an
     example for showing the total O VI column density in a ray::
 
         import trident
@@ -45,7 +45,7 @@ want to create a "dummy" metallicity field, include the following code at the
 top of your script to automatically add a uniform metallicity field to any
 datasets loaded lacking one (in this case it's 0.3 solar metallicity).  For more
 information on creating derived fields like this one, see the `yt documentation
-on derived fields 
+on derived fields
 <https://yt-project.org/docs/dev/developing/creating_derived_fields.html>`_
 ::
 
@@ -115,7 +115,7 @@ How do I learn more about the algorithms used in Trident?
 ---------------------------------------------------------
 
 We have a full description of all the methods used in Trident including
-citations to previous related works in our `Trident method paper 
+citations to previous related works in our `Trident method paper
 <http://adsabs.harvard.edu/abs/2017ApJ...847...59H>`_.
 
 How do I cite Trident in my research?

--- a/doc/source/help.rst
+++ b/doc/source/help.rst
@@ -9,7 +9,7 @@ steps below.  Don't worry, we'll help you get it sorted out.
 Update the Code
 ---------------
 
-The documentation is built for the latest version of Trident.  Try 
+The documentation is built for the latest version of Trident.  Try
 :ref:`updating` to assure your code matches what the documentation describes.
 Remember to `update to the latest version of yt too
 <http://yt-project.org/docs/dev/installing.html#updating-yt-and-its-dependencies>`_.
@@ -18,15 +18,15 @@ Search Documentation and Mailing List Archives
 ----------------------------------------------
 
 Most use cases for Trident can be found in our documentation and method paper.
-Try searching through the documentation using the search window in the upper 
-left part of the screen. 
+Try searching through the documentation using the search window in the upper
+left part of the screen.
 
-If that doesn't work, try looking at specific problems we might have 
+If that doesn't work, try looking at specific problems we might have
 addressed in our :ref:`faq`.
 
-Lastly, try searching the archives of our mailing list.  Chances are that 
-someone else may have encountered the problem that you have and already 
-wrote to the list.  You can search the list `here 
+Lastly, try searching the archives of our mailing list.  Chances are that
+someone else may have encountered the problem that you have and already
+wrote to the list.  You can search the list `here
 <https://groups.google.com/forum/#!forum/trident-project-users>`_.
 
 Contact our Mailing List
@@ -35,8 +35,8 @@ Contact our Mailing List
 Compose a message to our low-volume mailing list.  Remember to
 include details like the operating system you're using, the type of dataset
 you're trying to reduce, the version of Trident and yt you're using (find it
-out :ref:`here <what-version-am-i-running>`), and of course, a description of 
-the problem you're having with any relevant traceback errors.  
+out :ref:`here <what-version-am-i-running>`), and of course, a description of
+the problem you're having with any relevant traceback errors. 
 Our mailing list is located here::
 
   https://groups.google.com/forum/#!forum/trident-project-users

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,16 +1,16 @@
 Trident Documentation
 =====================
 
-Trident is a Python package for creating synthetic absorption-line spectra 
+Trident is a Python package for creating synthetic absorption-line spectra
 from astrophysical hydrodynamics simulations.  It utilizes the yt package
-to read in simulation datasets and extends it to provide realistic 
+to read in simulation datasets and extends it to provide realistic
 synthetic observations appropriate for studies of the interstellar,
 circumgalactic, and intergalactic media.
 
-To avoid confusion, make sure you are viewing the correct documentation for 
-the version of Trident you are using: 
+To avoid confusion, make sure you are viewing the correct documentation for
+the version of Trident you are using:
 `stable <http://trident.readthedocs.io/en/stable>`_ vs.
-`development <http://trident.readthedocs.io/en/latest>`_.  For more 
+`development <http://trident.readthedocs.io/en/latest>`_.  For more
 information, see :ref:`versions`.
 
 .. toctree::

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -20,6 +20,7 @@ information, see :ref:`versions`.
    annotated_example.rst
    advanced_spectra.rst
    ion_balance.rst
+   absorption_spectrum_fit.rst
    internals.rst
    testing.rst
    faq.rst

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -114,7 +114,7 @@ the up-to-date version of the source code and build it::
 
 Note, you'll also need a separate library,
 `yt_astro_analysis <https://github.com/yt-project/yt_astro_analysis.git>`_,
-to get some of the functianality necessary for Trident to work correctly::
+to get some of the functionality necessary for Trident to work correctly::
 
     $ git clone https://github.com/yt-project/yt_astro_analysis.git yt_astro_analysis
     $ cd yt_astro_analysis

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -58,7 +58,7 @@ some additional files.  See :ref:`step-3`, for more information::
     >>> import trident
 
 Follow the instructions to download the ion_balance table and then verify that
-everything is working correctly.  You should now be ready to do some 
+everything is working correctly.  You should now be ready to do some
 :ref:`step-4`
 
 Installing the Development Version of yt and Trident
@@ -217,7 +217,7 @@ please contact our mailing list.
 Uninstallation or Switching Code Versions
 -----------------------------------------
 
-Uninstallation of the Trident source code is easy.  If you installed the 
+Uninstallation of the Trident source code is easy.  If you installed the
 stable version of the code via pip, just run::
 
     $ pip uninstall trident

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -176,7 +176,7 @@ documentation for how to use it with your data or with one of our sample
 datasets.  A good place to start is the
 :ref:`annotated example <annotated-example>`, and the `example scripts found
 in the source code
-<https://github.com/trident-project/trident/blob/master/examples>`_.
+<https://github.com/trident-project/trident/blob/main/examples>`_.
 
 Please join our :ref:`mailing list
 <mailing-list>` or :ref:`slack channel <slack-channel>` for announcements
@@ -261,7 +261,7 @@ If you installed the "development" version of the code, it's slightly more
 involved::
 
     $ cd <YOUR_PATH_TO_TRIDENT_REPO>
-    $ git pull origin master
+    $ git pull origin main
     $ pip install -e .
     $ yt update
 

--- a/doc/source/ion_balance.rst
+++ b/doc/source/ion_balance.rst
@@ -4,9 +4,9 @@ Adding Ion Fields
 =================
 
 In addition to being able to create absorption spectra, Trident
-Trident can be used to postprocess datasets to add fields for ions not 
-explicitly tracked in the simulation.  These can later be analyzed 
-using the standard yt analysis packages.  This page provides some examples 
+Trident can be used to postprocess datasets to add fields for ions not
+explicitly tracked in the simulation.  These can later be analyzed
+using the standard yt analysis packages.  This page provides some examples
 as to how these fields can be generated and analyzed.
 
 How does it work?
@@ -16,16 +16,16 @@ When you installed Trident, you were forced to download an ion table, a
 data table consisting of dimensions in density, temperature, and redshift.
 This ion table was constructed by running many independent Cloudy instances
 to approximate the ionization states of all ionic species of the first 30
-elements.  The ionic species were calculated assuming collisional 
-ionization equilibrium based on different density and 
-temperature values and photoionization from a metagalactic ultraviolet 
+elements.  The ionic species were calculated assuming collisional
+ionization equilibrium based on different density and
+temperature values and photoionization from a metagalactic ultraviolet
 background unique to each ion table.  The currently preferred ion table
-uses the Haardt Madau 2012 model.  You can change your default 
+uses the Haardt Madau 2012 model.  You can change your default
 ionization model by changing your config file (see: :ref:`manual-config`), or
 by specifying it directly in the ``ionization_table`` keywords of the following
 functions.
 
-By following the process below, you will add different ion fields to your 
+By following the process below, you will add different ion fields to your
 dataset based on the above assumptions using the dataset's redshift, and
 the values of density, temperature, and metallicity found for each gas parcel
 in your dataset.
@@ -33,7 +33,7 @@ in your dataset.
 Generating species fields
 -------------------------
 
-As always, we first need to import yt and Trident and then we load up a 
+As always, we first need to import yt and Trident and then we load up a
 dataset::
 
    import yt
@@ -51,17 +51,17 @@ will add fields for whatever ions we specify in the form of:
 
 .. note::
 
-    Trident follows `yt's naming convention 
-    <http://ytep.readthedocs.io/en/latest/YTEPs/YTEP-0003.html#molecular-and-atomic-species-names>`_ 
+    Trident follows `yt's naming convention
+    <http://ytep.readthedocs.io/en/latest/YTEPs/YTEP-0003.html#molecular-and-atomic-species-names>`_
     for atomic, molecular, and ionic species fields.  In short, the ionic
-    prefix consists of the element and the number of times ionized it is:  
+    prefix consists of the element and the number of times ionized it is:
     e.g. H I = ``H_p0``, Mg II = ``Mg_p1``, O VI = ``O_p5`` (p is for plus).
 
 Let's add fields for O VI (five-times-ionized oxygen)::
 
    trident.add_ion_fields(ds, ions=['O VI'])
 
-To show how one can use this newly generated field, we'll make a projection 
+To show how one can use this newly generated field, we'll make a projection
 of the O VI number density field to show its column density map::
 
    proj = yt.ProjectionPlot(ds, "z", "O_p5_number_density")
@@ -71,12 +71,12 @@ which produces:
 
 .. image:: trident-docs-images/ions/RD0009_Projection_z_O_p5_number_density.png
 
-We can similarly create a phase plot to show where the O VI mass lives as a 
+We can similarly create a phase plot to show where the O VI mass lives as a
 function of density and temperature::
 
    # we need to create a data object from the dataset to make a phase plot
    ad = ds.all_data()
-   phase = yt.PhasePlot(ad, "density", "temperature", ["O_p5_mass"], 
+   phase = yt.PhasePlot(ad, "density", "temperature", ["O_p5_mass"],
                         weight_field="O_p5_mass", fractional=True)
    phase.save()
 

--- a/doc/source/ion_balance.rst
+++ b/doc/source/ion_balance.rst
@@ -41,7 +41,7 @@ dataset::
    fn = 'enzo_cosmology_plus/RD0009/RD0009'
    ds = yt.load(fn)
 
-To add ion fields we use the :class:`~trident.add_ion_fields` function.  This
+To add ion fields we use the :class:`~trident.ion_balance.add_ion_fields` function.  This
 will add fields for whatever ions we specify in the form of:
 
     * Ion fraction field. e.g. ``Mg_p1_ion_fraction``

--- a/doc/source/ion_balance.rst
+++ b/doc/source/ion_balance.rst
@@ -59,21 +59,7 @@ will add fields for whatever ions we specify in the form of:
 
 Let's add fields for O VI (five-times-ionized oxygen)::
 
-   trident.add_ion_fields(ds, ions=['O VI'], ftype="gas")
-
-.. warning::
-
-    Make sure you are using the appropriate value for `ftype` in adding your
-    ion fields to a dataset.  To get best results, the ion interpolation
-    must take place on the gas fields provided by your simulation output.  For
-    grid-based codes, these fields are typically aliased to the `gas` fields
-    (e.g., `("gas", "density")`), so using the default `ftype="gas"` is
-    fine.  But for particle-based codes, this is not usually the case, and the
-    particle-based gas fields differ based on the code (e.g. `PartType0`,
-    `Gas`, etc.).  Inspection of your dataset may be necessary 
-    (``print(ds.field_list)``).  Set `ftype` correctly to make sure
-    ion generation takes place on the particle first, before being deposited
-    to the grid-based fields, or you may get incorrect results.
+   trident.add_ion_fields(ds, ions=['O VI'])
 
 To show how one can use this newly generated field, we'll make a projection 
 of the O VI number density field to show its column density map::

--- a/doc/source/light_ray_generator.rst
+++ b/doc/source/light_ray_generator.rst
@@ -3,7 +3,7 @@
 Light Ray Generator
 ===================
 
-The :class:`~trident.LightRay` is the one-dimensional object representing
+The :class:`~trident.light_ray.LightRay` is the one-dimensional object representing
 the pencil beam of light traveling from the source to the observer. Light
 rays can stack multiple datasets together to span a redshift interval
 larger than the simulation box.
@@ -25,7 +25,7 @@ together.  The primary Trident interface to this is covered in
 :ref:`compound-ray`.  A light ray can also be made from a single dataset.
 For information on this, see :ref:`single-ray`.
 
-The arguments required to instantiate a :class:`~trident.LightRay` are
+The arguments required to instantiate a :class:`~trident.light_ray.LightRay` are
 the simulation parameter file, the simulation type, the nearest redshift,
 and the furthest redshift.
 

--- a/doc/source/reference.rst
+++ b/doc/source/reference.rst
@@ -10,9 +10,9 @@ Generating Rays
    :toctree: generated/
    :nosignatures:
 
-   ~trident.make_simple_ray
-   ~trident.make_compound_ray
-   ~trident.LightRay
+   ~trident.ray_generator.make_simple_ray
+   ~trident.ray_generator.make_compound_ray
+   ~trident.light_ray.LightRay
 
 Generating Spectra
 ------------------
@@ -21,12 +21,12 @@ Generating Spectra
    :toctree: generated/
    :nosignatures:
 
-   ~trident.SpectrumGenerator
+   ~trident.spectrum_generator.SpectrumGenerator
    ~trident.absorption_spectrum.absorption_spectrum.AbsorptionSpectrum
-   ~trident.Instrument
-   ~trident.LSF
-   ~trident.Line
-   ~trident.LineDatabase
+   ~trident.instrument.Instrument
+   ~trident.lsf.LSF
+   ~trident.line_database.Line
+   ~trident.line_database.LineDatabase
 
 Plotting Spectra
 ----------------
@@ -35,8 +35,8 @@ Plotting Spectra
    :toctree: generated/
    :nosignatures:
 
-   ~trident.load_spectrum
-   ~trident.plot_spectrum
+   ~trident.spectrum_generator.load_spectrum
+   ~trident.spectrum_generator.plot_spectrum
 
 Adding Ion Fields
 -----------------
@@ -45,11 +45,11 @@ Adding Ion Fields
    :toctree: generated/
    :nosignatures:
 
-   ~trident.add_ion_fields
-   ~trident.add_ion_fraction_field
-   ~trident.add_ion_number_density_field
-   ~trident.add_ion_density_field
-   ~trident.add_ion_mass_field
+   ~trident.ion_balance.add_ion_fields
+   ~trident.ion_balance.add_ion_fraction_field
+   ~trident.ion_balance.add_ion_number_density_field
+   ~trident.ion_balance.add_ion_density_field
+   ~trident.ion_balance.add_ion_mass_field
 
 Miscellaneous Utilities
 -----------------------
@@ -58,11 +58,11 @@ Miscellaneous Utilities
    :toctree: generated/
    :nosignatures:
 
-   ~trident.make_onezone_dataset
-   ~trident.make_onezone_ray
-   ~trident.to_roman
-   ~trident.from_roman
-   ~trident.trident_path
-   ~trident.trident
-   ~trident.verify
+   ~trident.utilities.make_onezone_dataset
+   ~trident.utilities.make_onezone_ray
+   ~trident.roman.to_roman
+   ~trident.roman.from_roman
+   ~trident.config.trident_path
+   ~trident.config.trident
+   ~trident.config.verify
    ~trident.absorption_spectrum.absorption_spectrum_fit.generate_total_fit

--- a/doc/source/testing.rst
+++ b/doc/source/testing.rst
@@ -44,16 +44,16 @@ before continuing with running the tests, otherwise your answer tests will
 fail.
 
 Make sure you're on the desired version of yt and trident that you want to 
-test and use (usually the tip of the development branch i.e., ``master``).  
+test and use (usually the tip of the development branch i.e., ``main``).  
 
 .. code-block:: bash
 
    $ export TRIDENT_GENERATE_TEST_RESULTS=0
    $ cd /path/to/yt/
-   $ git checkout master
+   $ git checkout main
    $ pip install -e .
    $ cd /path/to/trident
-   $ git checkout master
+   $ git checkout main
    $ pip install -e .
 
 The test suite is run by calling ``py.test`` from within the ``tests`` 

--- a/doc/source/testing.rst
+++ b/doc/source/testing.rst
@@ -5,10 +5,10 @@ Testing
 
 We maintain a series of tests in Trident to make sure the code gives consistent
 results and to catch accidental breakages in our source code and dependencies.
-These tests are run by `Travis <https://travis-ci.org/>`_ automatically and 
+These tests are run by `Travis <https://travis-ci.org/>`_ automatically and
 regularly to assure consistency in functionality, but you can run them locally
-too (see below).  The tests consist of a mix of unit tests (tests to assure Trident 
-functions don't actively fail) and answer tests (tests comparing newly 
+too (see below).  The tests consist of a mix of unit tests (tests to assure Trident
+functions don't actively fail) and answer tests (tests comparing newly
 generated results against some old established results to assure consistency).
 
 .. _running-the-tests:
@@ -27,10 +27,10 @@ installed with ``conda`` or ``pip``.
    $ conda install pytest
 
 The test suite requires a number of datasets for testing functionality.
-Trident comes with a helper script that will download all the datasets and 
-untar them.  Before running this, make sure you have the 
-``answer_test_data_dir`` variable set in your config file (see :ref:`step-3`).  
-This variable should point to a directory where these datasets will be stored.  
+Trident comes with a helper script that will download all the datasets and
+untar them.  Before running this, make sure you have the
+``answer_test_data_dir`` variable set in your config file (see :ref:`step-3`).
+This variable should point to a directory where these datasets will be stored.
 The helper script is located in the ``tests`` directory of the Trident source.
 
 .. code-block:: bash
@@ -39,12 +39,12 @@ The helper script is located in the ``tests`` directory of the Trident source.
    $ python download_test_data.py
 
 If this is your first time running the tests, then you need to generate a
-"gold standard" for the answer tests. Follow :ref:`generating-answer-tests` 
-before continuing with running the tests, otherwise your answer tests will 
+"gold standard" for the answer tests. Follow :ref:`generating-answer-tests`
+before continuing with running the tests, otherwise your answer tests will
 fail.
 
-Make sure you're on the desired version of yt and trident that you want to 
-test and use (usually the tip of the development branch i.e., ``main``).  
+Make sure you're on the desired version of yt and trident that you want to
+test and use (usually the tip of the development branch i.e., ``main``).
 
 .. code-block:: bash
 
@@ -56,7 +56,7 @@ test and use (usually the tip of the development branch i.e., ``main``).
    $ git checkout main
    $ pip install -e .
 
-The test suite is run by calling ``py.test`` from within the ``tests`` 
+The test suite is run by calling ``py.test`` from within the ``tests``
 directory.
 
 .. code-block:: bash
@@ -93,21 +93,21 @@ take around ten minutes to run.
 Generating Gold Standard Answer Test Results for Comparison
 -----------------------------------------------------------
 
-In order to assure the Trident codebase gives consistent results over time, 
-we compare the outputs of tests of new versions of Trident against an older, 
+In order to assure the Trident codebase gives consistent results over time,
+we compare the outputs of tests of new versions of Trident against an older,
 vetted version of the code we think gives accurate results.  To create this
-"gold standard" result from the older version of the code, you must roll back 
-the Trident and yt source back to the older "trusted" versions of the code.  
-You can find the tags for the most recent trusted versions of the code by 
-running ``gold_standard_versions.py`` and then rebuilding yt and Trident 
-with these versions of the code.  Lastly, set the 
+"gold standard" result from the older version of the code, you must roll back
+the Trident and yt source back to the older "trusted" versions of the code.
+You can find the tags for the most recent trusted versions of the code by
+running ``gold_standard_versions.py`` and then rebuilding yt and Trident
+with these versions of the code.  Lastly, set the
 ``TRIDENT_GENERATE_TEST_RESULTS`` environment variable to 1 and run the tests:
 
 .. code-block:: bash
 
    $ cd tests
    $ python gold_standard_versions.py
-   
+
    Latest Gold Standard Commit Tags
    yt = 953248239966
    Trident = test-standard-v2
@@ -125,8 +125,8 @@ with these versions of the code.  Lastly, set the
    $ py.test
 
 The test results should now be stored in the ``answer_test_data_dir`` that
-you specified in your Trident configuration file. You may now run the actual 
-tests (see :ref:`running-the-tests`) with your current version of yt and 
+you specified in your Trident configuration file. You may now run the actual
+tests (see :ref:`running-the-tests`) with your current version of yt and
 Trident comparing against these gold standard results.
 
 .. _tests-broken:
@@ -157,10 +157,10 @@ the code, then you'll simply want to go about :ref:`updating-the-test-results`.
 Updating the Testing Gold Standard
 ----------------------------------
 
-Periodically, the gold standard for our answer tests must be updated as bugs 
+Periodically, the gold standard for our answer tests must be updated as bugs
 are caught or new more accurate behavior is enabled that causes the answer
 tests to fail.  The first thing to do
-is to identify the most accurate version of the code (e.g., changesets for 
+is to identify the most accurate version of the code (e.g., changesets for
 yt and trident that give the desired behavior).  Tag the Trident changeset with
 the next gold standard iteration.  You can see the current iteration by looking
 in the ``.travis.yml`` file at the ``TRIDENT_GOLD`` entry--increment this and
@@ -188,5 +188,5 @@ tag.
    $ git push upstream test-standard-v3
 
 Lastly, that person will have to also
-clear Travis' cache, so that it regenerates new answer test results.  This can 
+clear Travis' cache, so that it regenerates new answer test results.  This can
 be done manually here: https://travis-ci.org/trident-project/trident/caches .


### PR DESCRIPTION
Something changed somewhere about a year ago in a dependency and our API docs haven't been showing up on readthedocs (see Issue #156 ).  This PR fixes most of that problem.  It cannot display `LightRay` or the Ray generator functions yet, though, because right now stable `yt_astro_analysis` still uses an old broken reference in yt, and it's hosts the superclass for `LightRay`.  But hopefully this will get addressed when a new version of `yt_astro_analysis` is released.

While I was at it, I updated the docs to also fix #152 and #173 and generally provide more instructions on how to do stuff.