### PR TITLE
Adding hint kwarg upon LightRay load to break degeneracy in new yt loader

### DIFF
--- a/trident/light_ray.py
+++ b/trident/light_ray.py
@@ -722,7 +722,7 @@ class LightRay(CosmologySplice):
 
         if data_filename is not None:
             self._write_light_ray(data_filename, all_data)
-            ray_ds = load(data_filename)
+            ray_ds = load(data_filename, hint='YTDataLightRayDataset')
 
             # temporary fix for yt-4.0 ytdata selection issue
             ray_ds.domain_left_edge = ray_ds.domain_left_edge.to('code_length')


### PR DESCRIPTION
A recent change in yt ([PR #3666](https://github.com/yt-project/yt/pull/3666)) breaks trident when trident reloads a LightRay object into working memory.  This one-line change provides a "hint" that breaks the degeneracy in Datasets types that yt is confused about, and allows Trident to continue working the way it used to.

This bug was discovered by @evaneschneider , so I'll let her comment on how well this fix works for her case.