### PR TITLE
Correcting branch switch for circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -318,7 +318,7 @@ workflows:
            filters:
             branches:
               only:
-                - master
+                - main
      jobs:
        - tests:
            name: "Python 3.7 tests with yt gold"


### PR DESCRIPTION
Small change to ensure circleci is building from the main branch of trident.  Was previously just using old master branch in weekly builds.