### PR TITLE
Explicitly load LightRayDataset to avoid hint kwarg

### DIFF
--- a/trident/light_ray.py
+++ b/trident/light_ray.py
@@ -22,6 +22,8 @@ from yt.loaders import \
     load
 from yt.frontends.ytdata.utilities import \
     save_as_dataset
+from yt.frontends.ytdata.data_structures import \
+    YTDataLightRayDataset
 from yt.units.yt_array import \
     YTArray
 from yt.utilities.cosmology import \
@@ -31,8 +33,10 @@ from yt.utilities.logger import \
 from yt.utilities.parallel_tools.parallel_analysis_interface import \
     parallel_objects, \
     parallel_root_only
-from yt.utilities.physical_constants import speed_of_light_cgs
-from yt.data_objects.static_output import Dataset
+from yt.utilities.physical_constants import \
+    speed_of_light_cgs
+from yt.data_objects.static_output import \
+    Dataset
 
 class LightRay(CosmologySplice):
     r"""
@@ -722,7 +726,7 @@ class LightRay(CosmologySplice):
 
         if data_filename is not None:
             self._write_light_ray(data_filename, all_data)
-            ray_ds = load(data_filename, hint='YTDataLightRayDataset')
+            ray_ds = YTDataLightRayDataset(data_filename)
 
             # temporary fix for yt-4.0 ytdata selection issue
             ray_ds.domain_left_edge = ray_ds.domain_left_edge.to('code_length')


### PR DESCRIPTION
The tests are failing because of a short-sighted change I made to use the "hint" kwarg in the load() command.  Basically, yt has some ambiguity when we load the LightRay datasets, and it gets upset, so I had previously added the "hint" kwarg to load to tell load that the datasets were LightRays.  But "hint" wasn't implemented until last year (2021), which is *after* the changeset of our yt gold standard (2018), so the tests against the yt gold standard fail because they try to use the "hint" functionality that doesn't yet exist.  

This change fixes all of that, by explicitly loading the LightRay datasets instead of messing with "load" or "hint" or any of that.