### PR TITLE
Redshift alignment for simple rays

### DIFF
--- a/trident/ion_balance.py
+++ b/trident/ion_balance.py
@@ -134,13 +134,7 @@ def add_ion_fields(ds, ions, ftype='gas',
                    field_suffix=False,
                    line_database=None,
                    sampling_type='local',
-                   particle_type=None,
-                   metal_source = 'best',
-                   H_source = 'best',
-                   He_source = 'best',
-                   custom_metal_function = None,
-                   custom_H_function = None,
-                   custom_He_function = None):
+                   particle_type=None):
     """
     Preferred method for adding ion fields to a yt dataset.
 
@@ -280,17 +274,6 @@ def add_ion_fields(ds, ions, ftype='gas',
     # - X_P#_number_density
     # - X_P#_density
     for (atom, ion) in ion_list:
-        add_nucleus_density_field(atom, ion, ds, 
-                       ftype = ftype,
-                       sampling_type = sampling_type,
-                       particle_type = particle_type,
-                       metal_source = metal_source,
-                       H_source = H_source,
-                       He_source = He_source,
-                       custom_metal_function = custom_metal_function,
-                       custom_H_function = custom_H_function,
-                       custom_He_function = custom_He_function)
-        
         add_ion_mass_field(atom, ion, ds, ftype, ionization_table,
             field_suffix=field_suffix, sampling_type=sampling_type)
 
@@ -674,8 +657,6 @@ def add_ion_mass_field(atom, ion, ds, ftype="gas",
 
     _add_field(ds, ("gas", field), function=_ion_mass, units=r"g",
                sampling_type=sampling_type)
-    
-
 
 def _ion_mass(field, data):
     """
@@ -690,14 +671,36 @@ def _ion_mass(field, data):
         ftype = "gas"
         field_name = field.name
     atom = field_name.split("_")[0]
-    atom_mass = atomic_mass[atom]*mh
     prefix = field_name.split("_mass")[0]
     suffix = field_name.split("_mass")[-1]
     fraction_field_name = "%s_ion_fraction%s" % (prefix, suffix)
-    fraction_field = data[ftype,fraction_field_name]
-    effective_volume = data[ftype,'mass']/data[ftype,'density']
-    nucleus_density_field = data[ftype, 'trident_%s_nuclei_density'%atom]
-    return fraction_field * nucleus_density_field * effective_volume * atom_mass
+
+    # try the atom-specific density field first
+    nuclei_field = "%s_nuclei_mass" % atom
+    if (ftype, nuclei_field) in data.ds.field_info:
+        return data[ftype,fraction_field_name] * \
+          data[ftype, nuclei_field]
+
+    # try the species metallicity
+    metallicity_field = "%s_metallicity" % atom
+    if (ftype, metallicity_field) in data.ds.field_info:
+        return data[ftype,fraction_field_name] * \
+          data[ftype, "mass"] * \
+          data[ftype, metallicity_field]
+
+    if atom == 'H' or atom == 'He':
+        mass_fraction = solar_abundance[atom] * data[ftype,fraction_field_name]
+    else:
+        mass_fraction = data.ds.quan(solar_abundance[atom], "1.0/Zsun") * \
+          data[ftype, fraction_field_name] * \
+          data[ftype, "metallicity"]
+    # convert to total mass
+    # use the on disk hydrogen mass if possible
+    if (ftype, "H_nuclei_mass") in data.ds.derived_field_list:
+        mass = mass_fraction * data[ftype, "H_nuclei_mass"]
+    else:
+        mass = mass_fraction * data[ftype, "mass"] * H_mass_fraction
+    return mass
 
 def _ion_density(field, data):
     """
@@ -731,13 +734,37 @@ def _ion_number_density(field, data):
         ftype = "gas"
         field_name = field.name
     atom = field_name.split("_")[0]
-    atom_mass = atomic_mass[atom]*mh
     prefix = field_name.split("_number_density")[0]
     suffix = field_name.split("_number_density")[-1]
     fraction_field_name = "%s_ion_fraction%s" % (prefix, suffix)
-    fraction_field = data[ftype,fraction_field_name]
-    nucleus_density_field = data[ftype, 'trident_%s_nuclei_density'%atom]
-    return fraction_field * nucleus_density_field 
+
+    # try the atom-specific density field first
+    nuclei_field = "%s_nuclei_mass_density" % atom
+    if (ftype, nuclei_field) in data.ds.field_info:
+        return data[ftype, fraction_field_name] * \
+          data[(ftype, nuclei_field)] / (atomic_mass[atom] * mh)
+
+    # try the species metallicity
+    metallicity_field = "%s_metallicity" % atom
+    if (ftype, metallicity_field) in data.ds.field_info:
+        return data[ftype, fraction_field_name] * \
+          data[ftype, "density"] * \
+          data[ftype, metallicity_field] / \
+          atomic_mass[atom] / mh
+
+    if atom == 'H' or atom == 'He':
+        number_density = solar_abundance[atom] * data[ftype, fraction_field_name]
+    else:
+        number_density = data.ds.quan(solar_abundance[atom], "1.0/Zsun") * \
+          data[ftype, fraction_field_name] * \
+          data[ftype, "metallicity"]
+    # convert to number density
+    # use the on disk hydrogen number density if possible
+    if (ftype, "H_nuclei_density") in data.ds.derived_field_list:
+        number_density = number_density * data[ftype, "H_nuclei_density"]
+    else:
+        number_density = number_density * data[ftype, "density"] * to_nH
+    return number_density
 
 def _ion_fraction_field(field, data):
     """
@@ -836,157 +863,7 @@ def _alias_field(ds, alias_name, name):
     return
 
 
-def add_nucleus_density_field(atom, ion, ds, ftype="gas",
-                       sampling_type='local',
-                       particle_type=None,
-                       metal_source = 'best',
-                       H_source = 'best',
-                       He_source = 'best',
-                       custom_metal_function = None,
-                       custom_H_function = None,
-                       custom_He_function = None):
-    
-    if atom == 'H':
-        field = 'trident_H_nuclei_density'
-        field_function = create_H_number_density_function(ftype,
-                                     H_source,
-                                     custom_H_function)
-    elif atom == 'He':
-        field = 'trident_He_nuclei_density'
-        field_function = create_He_number_density_function(ftype,
-                                     He_source,
-                                     custom_He_function)
-    else:
-        field = 'trident_%s_nuclei_density'%atom
-        field_function = create_metal_number_density_function(atom,ftype,
-                                                              metal_source,
-                                                              custom_metal_function)
-    _add_field(ds, ("gas", field), 
-           function=field_function,
-           units=r"cm**-3",
-           sampling_type=sampling_type)
-    
-def create_metal_number_density_function(atom,ftype,
-                                         metal_source,
-                                         custom_metal_function):
-
-    def _metal_processing(field,data):
-        #returns metals in units of number density
-        #uses best (most specific) data available, unless forced otherwise
-        if isinstance(field.name, tuple):
-            ftype = field.name[0]
-            field_name = field.name[1]
-        else:
-            ftype = "gas"
-            field_name = field.name
-        atom = field_name.split("_")[1]
-        atom_mass = atomic_mass[atom]*mh
-        # try the atom-specific density field first
-        if metal_source == 'best' or metal_source == "nuclei_density":
-            nuclei_field = "%s_nuclei_density" % atom
-            if (ftype, nuclei_field) in data.ds.field_info\
-                    or metal_source == "nuclei_density":
-                return data[ftype, nuclei_field]
-        # try the atom-specific mass field
-        if metal_source == 'best' or metal_source == "nuclei_mass":
-            nuclei_mass_field = "%s_nuclei_mass" % atom
-            effective_volume = data[ftype, 'mass']/data[ftype, 'density']
-            if (ftype, nuclei_mass_field) in data.ds.field_info\
-                    or metal_source == "nuclei_mass":
-                return data[ftype, nuclei_mass_field]/effective_volume/atom_mass
-        # try the species metallicity
-        if metal_source == 'best' or metal_source == "species_metallicity":
-            species_metallicity_field = "%s_metallicity" % atom
-            if (ftype, species_metallicity_field) in data.ds.field_info \
-                    or metal_source == "species_metallicity":
-                return data[ftype, species_metallicity_field]*data[ftype, 'density']/atom_mass
-        # try regular metallicity
-        if metal_source == 'best' or metal_source == "metallicity":
-            if (ftype, "metallicity") in data.ds.field_info \
-                    or metal_source == "metallicity":
-                return data[ftype, "metallicity"]*\
-                        data[ftype, 'density']*data.ds.quan(solar_abundance[atom],'1/Zsun')*to_nH
-        # you've required something besides regular metallicity
-        # custom_function is how you explain it
-        if metal_source == 'custom':
-            assert custom_metal_function is not None, f'field {field} requires a custom function for atomic '\
-                                        'abundance. metal_source = custom but no custom_metal_function specified'
-            return custom_metal_function(field,data)
-        assert 0, f'field {field} could not be generated by any path. '\
-                    f'require_fname = {require_fname},require_type = {require_type}'
-        
-    return _metal_processing
-    
-def create_H_number_density_function(ftype,
-                                     H_source,
-                                     custom_H_function):
-    
-    def _H_processing(field,data):
-        #returns hydrogen density in units of number density
-        #uses best (most specific) data available, unless forced otherwise
-        atom = 'H'
-        atom_mass = atomic_mass[atom]*mh
-        # try the atom-specific density field first
-        if H_source == 'best' or H_source == "nuclei_density":
-            if (ftype,  "nuclei_density") in data.ds.field_info\
-                    or H_source == "nuclei_density":
-                return data[ftype, "H_nuclei_density"]
-        # try the atom-specific mass field
-        if H_source == 'best' or H_source == "nuclei_mass":
-            effective_volume = data[ftype, 'mass']/data[ftype, 'density']
-            if (ftype, "H_nuclei_mass") in data.ds.field_info\
-                    or H_source == "nuclei_mass":
-                return data[ftype, "H_nuclei_mass"]/effective_volume/atom_mass
-        if H_source == 'best' or H_source == "density":
-            if (ftype, 'density') in data.ds.field_info\
-                    or H_source == "density":
-                return data[ftype, 'density']*to_nH
-        # you've required something besides regular metallicity
-        # custom_function is how you explain it
-        if H_source == 'custom':
-            assert custom_H_function is not None, f'field {field} requires a custom function for atomic '\
-                                        'abundance. H_source = custom but no custom_H_function specified'
-            return custom_H_function(field,data)
-        assert 0, f'field {field} could not be generated by any path. '\
-                    f'require_fname = {require_fname},require_type = {require_type}'           
-    
-    return _H_processing
-    
-def create_He_number_density_function(ftype,
-                                     He_source,
-                                     custom_He_function):
-    
-    def _He_processing(field,data):
-        #returns hydrogen density in units of number density
-        #uses best (most specific) data available, unless forced otherwise
-        atom = 'He'
-        atom_mass = atomic_mass[atom]*mh
-        # try the atom-specific density field first
-        if He_source == 'best' or He_source == "nuclei_density":
-            if (ftype, "He_nuclei_density") in data.ds.field_info\
-                    or He_source == "nuclei_density":
-                return data[ftype, "He_nuclei_density"]
-        # try the atom-specific mass field
-        if He_source == 'best' or He_source == "nuclei_mass":
-            effective_volume = data[ftype, 'mass']/data[ftype, 'density']
-            if (ftype, "He_nuclei_mass") in data.ds.field_info\
-                    or He_source == "nuclei_mass":
-                return data[ftype, "He_nuclei_mass"]/effective_volume/atom_mass
-        if He_source == 'best' or He_source == "hydrogen":
-            if (ftype, "H_nuclei_mass") in data.ds.field_info\
-                    or He_source == "hydrogen":
-                return data[ftype, 'density']*to_nH*solar_abundance['He']
-        # you've required something besides regular metallicity
-        # custom_function is how you explain it
-        if He_source == 'custom':
-            assert custom_He_function is not None, f'field {field} requires a custom function for atomic '\
-                                        'abundance. He_source = custom but no custom_He_function specified'
-            return custom_He_function(field,data)
-        assert 0, f'field {field} could not be generated by any path. '\
-                    f'require_fname = {require_fname},require_type = {require_type}'           
-    
-    return _He_processing
-
+# Taken from Cloudy documentation.
 solar_abundance = {
     'H' : 1.00e+00, 'He': 1.00e-01, 'Li': 2.04e-09,
     'Be': 2.63e-11, 'B' : 6.17e-10, 'C' : 2.45e-04,
@@ -999,7 +876,6 @@ solar_abundance = {
     'Mn': 2.88e-07, 'Fe': 2.82e-05, 'Co': 8.32e-08,
     'Ni': 1.78e-06, 'Cu': 1.62e-08, 'Zn': 3.98e-08}
 
-# Taken from Cloudy documentation.
 atomic_mass = {
     'H' : 1.00794,   'He': 4.002602,  'Li': 6.941,
     'Be': 9.012182,  'B' : 10.811,    'C' : 12.0107,

--- a/trident/light_ray.py
+++ b/trident/light_ray.py
@@ -568,8 +568,8 @@ class LightRay(CosmologySplice):
                     segment_length = my_segment["traversal_box_fraction"] * \
                       ds.domain_width[0].in_units("Mpccm / h")
                 next_redshift = my_segment["redshift"] - \
-                  self._deltaz_forward(my_segment["redshift"],
-                                       segment_length)
+                        self._deltaz_forward(my_segment["redshift"],
+                                                    segment_length)
             elif my_segment.get("next", None) is None:
                 next_redshift = self.near_redshift
             else:
@@ -683,10 +683,14 @@ class LightRay(CosmologySplice):
                   (my_segment['redshift'] - next_redshift)
             elif redshift_align == 'center':
                 sub_data['redshift'] = my_segment['redshift'] - \
-                  ((sub_data['l']-ray_length/2) / (ray_length/2)) * \
+                  ((sub_data['l']-ray_length/2) / ray_length) * \
                   (my_segment['redshift'] - next_redshift)
             elif redshift_align == 'everywhere':
-                sub_data['redshift'] = my_segment['redshift']
+                sub_data['redshift'] = np.ones(sub_data['l'].shape)*my_segment['redshift']
+            else:
+                mylog.warning('redshift_align not recognized. Using z = z_start for full length')
+                sub_data['redshift'] = np.ones(sub_data['l'].shape)*my_segment['redshift']
+
             # When using the peculiar velocity, create effective redshift
             # (redshift_eff) field combining cosmological redshift and
             # doppler redshift.

--- a/trident/light_ray.py
+++ b/trident/light_ray.py
@@ -314,8 +314,8 @@ class LightRay(CosmologySplice):
                        trajectory=None,fields=None, setup_function=None,
                        solution_filename=None, data_filename=None,
                        get_los_velocity=None, use_peculiar_velocity=True,
-                       redshift=None, field_parameters=None,
-                       redshift_align = 'start',njobs=-1):
+                       redshift=None, redshift_align=None,
+                       field_parameters=None, njobs=-1):
         """
         Actually generate the LightRay by traversing the desired dataset.
 
@@ -419,7 +419,19 @@ class LightRay(CosmologySplice):
             redshift will be 0 for a non-cosmological dataset and
             the dataset redshift for a cosmological dataset.
             Default: None.
-
+            
+        :redshift_align: optional, str
+        
+            Used with light rays with single datasets to specify where the 
+            redshift is "equal" to the redshift of the dataset, or "redshift"
+            if that was specified. If "start" or None, the line start will be 
+            at this redshift and the line end will be at a lower redshift. 
+            Other options are "center", so the line start will be greater than 
+            this redshift, the line end will be less, and they will align at the
+            midpoint, and "everywhere", so the line will be at this redshift
+            throughout.
+            Default: None.
+            
         :field_parameters: optional, dict
             Used to set field parameters in light rays. For example,
             if the 'bulk_velocity' field parameter is set, the relative
@@ -553,7 +565,10 @@ class LightRay(CosmologySplice):
                     mylog.warning("Generating light ray with different redshift than " +
                                   "the dataset itself.")
                 my_segment["redshift"] = redshift
-
+                
+            if redshift_align is None:
+                redshift_align = 'start'
+                
             if setup_function is not None:
                 setup_function(ds)
 
@@ -678,18 +693,20 @@ class LightRay(CosmologySplice):
             # Get redshift for each lixel.  Assume linear relation between l
             # and z.  so z = z_start - z_range * (l / l_range)
             if redshift_align == 'start':
-                sub_data['redshift'] = my_segment['redshift'] - \
-                  (sub_data['l'] / ray_length) * \
+                sub_data[('gas','redshift')] = my_segment['redshift'] - \
+                  (sub_data[('gas','l')] / ray_length) * \
                   (my_segment['redshift'] - next_redshift)
             elif redshift_align == 'center':
-                sub_data['redshift'] = my_segment['redshift'] - \
-                  ((sub_data['l']-ray_length/2) / ray_length) * \
+                sub_data[('gas','redshift')] = my_segment['redshift'] - \
+                  ((sub_data[('gas','l')]-ray_length/2) / ray_length) * \
                   (my_segment['redshift'] - next_redshift)
             elif redshift_align == 'everywhere':
-                sub_data['redshift'] = np.ones(sub_data['l'].shape)*my_segment['redshift']
+                sub_data[('gas','redshift')] = np.ones(sub_data[('gas','l')].shape)*\
+                  my_segment['redshift']
             else:
                 mylog.warning('redshift_align not recognized. Using z = z_start for full length')
-                sub_data['redshift'] = np.ones(sub_data['l'].shape)*my_segment['redshift']
+                sub_data[('gas','redshift')] = np.ones(sub_data[('gas','l')].shape)*\
+                  my_segment['redshift']
 
             # When using the peculiar velocity, create effective redshift
             # (redshift_eff) field combining cosmological redshift and

--- a/trident/light_ray.py
+++ b/trident/light_ray.py
@@ -311,7 +311,7 @@ class LightRay(CosmologySplice):
     def make_light_ray(self, seed=None, periodic=True,
                        left_edge=None, right_edge=None, min_level=None,
                        start_position=None, end_position=None,
-                       trajectory=None,fields=None, setup_function=None,
+                       trajectory=None, fields=None, setup_function=None,
                        solution_filename=None, data_filename=None,
                        get_los_velocity=None, use_peculiar_velocity=True,
                        redshift=None, redshift_align=None,
@@ -583,8 +583,8 @@ class LightRay(CosmologySplice):
                     segment_length = my_segment["traversal_box_fraction"] * \
                       ds.domain_width[0].in_units("Mpccm / h")
                 next_redshift = my_segment["redshift"] - \
-                        self._deltaz_forward(my_segment["redshift"],
-                                                    segment_length)
+                    self._deltaz_forward(my_segment["redshift"],
+                                                segment_length)
             elif my_segment.get("next", None) is None:
                 next_redshift = self.near_redshift
             else:
@@ -691,7 +691,10 @@ class LightRay(CosmologySplice):
                 sub_data[key] = ds.arr(sub_data[key]).in_cgs()
 
             # Get redshift for each lixel.  Assume linear relation between l
-            # and z.  so z = z_start - z_range * (l / l_range)
+            # and z, depending on where they should be "aligned".
+            # 'start':      z = z_dataset - z_range * (l / l_range)
+            # 'center':     z = z_dataset - z_range * ((l - l_range/2) / l_range)
+            # 'everywhere': z = z_dataset
             if redshift_align == 'start':
                 sub_data[('gas','redshift')] = my_segment['redshift'] - \
                   (sub_data[('gas','l')] / ray_length) * \
@@ -704,7 +707,8 @@ class LightRay(CosmologySplice):
                 sub_data[('gas','redshift')] = np.ones(sub_data[('gas','l')].shape)*\
                   my_segment['redshift']
             else:
-                mylog.warning('redshift_align not recognized. Using z = z_start for full length')
+                mylog.warning(f'redshift_align {redshift_aligh} not recognized. '+\
+                              'Using z = z_start for full length')
                 sub_data[('gas','redshift')] = np.ones(sub_data[('gas','l')].shape)*\
                   my_segment['redshift']
 

--- a/trident/ray_generator.py
+++ b/trident/ray_generator.py
@@ -30,7 +30,8 @@ from trident.ion_balance import \
 def make_simple_ray(dataset_file, start_position, end_position,
                     lines=None, ftype="gas", fields=None,
                     solution_filename=None, data_filename=None,
-                    trajectory=None, redshift=None, field_parameters=None,
+                    trajectory=None, redshift=None,
+                    redshift_align='start', field_parameters=None,
                     setup_function=None, load_kwargs=None,
                     line_database=None, ionization_table=None):
     """
@@ -124,10 +125,19 @@ def make_simple_ray(dataset_file, start_position, end_position,
 
     :redshift: float, optional
 
-        Sets the highest cosmological redshift of the ray.  By default, it will
+        Sets the base cosmological redshift of the ray.  By default, it will
         use the cosmological redshift of the dataset, if set, and if not set,
         it will use a redshift of 0.
         Default: None
+        
+    :redshift_align: optional, str
+
+        Sets the location where the cosmological redshift "aligns" with the base
+        cosmological redshift. Default is the start of the ray, other options are 
+        'center', so the start will be higher redshift and the end will be lower,
+        and 'everywhere', so the full length will be at the base cosmological 
+        redshift
+        Default: 'start'
 
     :field_parameters: optional, dict
         Used to set field parameters in light rays. For example,
@@ -231,7 +241,8 @@ def make_simple_ray(dataset_file, start_position, end_position,
                              solution_filename=solution_filename,
                              data_filename=data_filename,
                              field_parameters=field_parameters,
-                             redshift=redshift)
+                             redshift=redshift,
+                             redshift_align=redshift_align)
 
 def make_compound_ray(parameter_filename, simulation_type,
                       near_redshift, far_redshift,


### PR DESCRIPTION
When using `make_simple_ray` to run sightlines with TRIDENT for AGORA Cosmorun, we discovered a weird behavior: components were biased towards negative velocities. This was true for all ion lines, at all redshifts, in all codes, so it was clear that it was some kind of TRIDENT behavior. (thinking this bias might be from "running out of components" is what prompted #195, though that ended up not being the case). 

<img width="398" alt="Screen Shot 2023-03-30 at 6 01 06 PM" src="https://user-images.githubusercontent.com/33767568/228996704-056a100e-7fc6-4de3-b192-6f47d040187b.png">

In fact, what's happening *is* intended behavior, not a bug, though I would argue users who make simple rays probably don't expect it to work the way it does. Since the line is created in a cosmological simulation, the redshift of the line is taken to be the dataset redshift. However, as the line travels, it goes to lower redshift, so the end of the line is "closer" to the observer. In other words, lines are blueshifted relative to the dataset. So, transforming the wavelengths into velocities using     

`v_ion = speedoflight*(wl/(line_rest_wl*(1+cosmo_redshift))-1)`

gives all the lines a negative velocity of around 100 km/s, which has no relationship with the halo velocity. I tested this by comparing the same sightline twice, once with `end` and `start` reversed, and they were always mirrored around -100 km/s.

My solution was to change how `sub_data[('gas','redshift')]` is defined for each lixel by adding a new optional parameter `redshift_align`. The prior behavior would align the dataset redshift with the start of the sightline, no matter where it points or where the absorption takes place. I had two ideas for what this should be replaced with.

1. `redshift_align = 'center'` gives z>z_ds at the line start, z<z_ds at the line end, and z = z_ds at the midpoint of the line. If you make endpoints like I do, so they are supposed to pass by the galaxy at their midpoint, this will give the cgm aligned with the box, and slightly blueshift the "end" side and redshift the "start" side.
2. `redshift_align = 'everywhere'` gives z = z_ds for the whole duration of the line. (this was my first solution, because it was easier to figure out)

![redshift_align_ex](https://user-images.githubusercontent.com/33767568/229000094-6566bbc3-d1a7-4beb-bf67-acb8ba8cdb38.png)

The pros of 'center' are that the line is more cosmologically realistic, the pros of 'everywhere' is that the velocities are more intuitively correct, i.e. velocity on this graph is the real LOS velocity of the cloud. The difference is minor but noticeable, but in any case it is much less significant than defaulting to 'start'. I added both as options here. If the user passes in some other argument, I figured "everywhere" is the most simple option, so I added a warning and used that.

I don't think this makes sense for `complex_rays`, so I didn't add it to that function, though would be happy to discuss that if anyone wants. I don't understand how `complex_rays` work nearly as well, and have never made one.
