### PR TITLE
Fixing failing tests by updating versions of Python tested

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -310,11 +310,6 @@ workflows:
            yttag: "YT_HEAD"
 
        - tests:
-           name: "Python 3.12 tests with yt tip"
-           tag: "3.12.0"
-           yttag: "YT_HEAD"
-
-       - tests:
            name: "Python 3.11 tests with yt gold"
            tag: "3.11.4"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -294,28 +294,33 @@ workflows:
    normal-tests:
      jobs:
        - tests:
-           name: "Python 3.8 tests with yt tip"
-           tag: "3.8.14"
-           yttag: "YT_HEAD"
-
-       - tests:
            name: "Python 3.9 tests with yt tip"
-           tag: "3.9.14"
+           tag: "3.9.13"
            yttag: "YT_HEAD"
 
        - tests:
            name: "Python 3.10 tests with yt tip"
-           tag: "3.10.7"
+           tag: "3.10.13"
            yttag: "YT_HEAD"
            coverage: 1
 
        - tests:
-           name: "Python 3.10 tests with yt gold"
-           tag: "3.10.7"
+           name: "Python 3.11 tests with yt tip"
+           tag: "3.11.4"
+           yttag: "YT_HEAD"
+
+       - tests:
+           name: "Python 3.12 tests with yt tip"
+           tag: "3.12.0"
+           yttag: "YT_HEAD"
+
+       - tests:
+           name: "Python 3.11 tests with yt gold"
+           tag: "3.11.4"
 
        - docs-test:
            name: "Test docs build"
-           tag: "3.9.14"
+           tag: "3.11.4"
 
    weekly:
      triggers:
@@ -327,21 +332,21 @@ workflows:
                 - main
      jobs:
        - tests:
-           name: "Python 3.8 tests with yt gold"
-           tag: "3.8.14"
+           name: "Python 3.9 tests with yt gold"
+           tag: "3.9.13"
 
        - tests:
-           name: "Python 3.8 tests with yt tip"
-           tag: "3.8.14"
+           name: "Python 3.9 tests with yt tip"
+           tag: "3.9.13"
            yttag: "YT_HEAD"
            coverage: 0
 
        - tests:
-           name: "Python 3.10 tests with yt tip"
-           tag: "3.10.7"
+           name: "Python 3.11 tests with yt tip"
+           tag: "3.11.4"
            yttag: "YT_HEAD"
            coverage: 0
 
        - docs-test:
            name: "Test docs build"
-           tag: "3.9.14"
+           tag: "3.11.4"

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,6 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
-        "Programming Language :: Python :: 3.12",
         "Topic :: Scientific/Engineering :: Astronomy",
         "Topic :: Scientific/Engineering :: Physics",
         "Topic :: Scientific/Engineering :: Visualization",

--- a/setup.py
+++ b/setup.py
@@ -44,9 +44,10 @@ setup(
         "License :: OSI Approved :: BSD License",
         "Natural Language :: English",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: Scientific/Engineering :: Astronomy",
         "Topic :: Scientific/Engineering :: Physics",
         "Topic :: Scientific/Engineering :: Visualization",
@@ -63,5 +64,5 @@ setup(
         'scipy',
         'yt>=4.0.1',
         'yt_astro_analysis>=1.1.0'],
-      python_requires='>=3.7'
+      python_requires='>=3.9'
 )


### PR DESCRIPTION
yt stopped supporting python 3.8, which caused our 3.8 tests to fail.  This updates to the newer versions of python consistent with our primary dependency, yt.