### PR TITLE
Fix deprecations in testing infrastructure

### DIFF
--- a/tests/test_absorption_spectrum.py
+++ b/tests/test_absorption_spectrum.py
@@ -15,7 +15,8 @@ import numpy as np
 import os
 from yt.loaders import load
 from yt.testing import \
-    assert_allclose_units, \
+    assert_allclose_units
+from numpy.testing import \
     assert_almost_equal
 
 from trident.absorption_spectrum.absorption_line import \

--- a/tests/test_auto_lambda.py
+++ b/tests/test_auto_lambda.py
@@ -12,7 +12,7 @@ tests for auto-lambda feature
 
 import os
 from yt.loaders import load
-from yt.testing import \
+from numpy.testing import \
     assert_allclose
 
 from trident import \

--- a/tests/test_light_ray.py
+++ b/tests/test_light_ray.py
@@ -15,7 +15,7 @@ import numpy as np
 
 from yt.loaders import \
     load
-from yt.testing import \
+from numpy.testing import \
     assert_array_equal, \
     assert_almost_equal
 from trident import \

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -14,7 +14,7 @@ Tests to assure the code runs on example pipelines
 import h5py
 import os
 from yt.loaders import load
-from yt.testing import \
+from numpy.testing import \
     assert_almost_equal
 
 from trident import \

--- a/tests/test_velocity_space.py
+++ b/tests/test_velocity_space.py
@@ -12,7 +12,7 @@ tests for velocity bin space
 
 import os
 from yt.loaders import load
-from yt.testing import \
+from numpy.testing import \
     assert_allclose
 
 from trident import \


### PR DESCRIPTION
A number of deprecations had been added to yt recently that were causing warnings in the testing infrastructure.  This successfully addresses that problem by importing testing functions directly from numpy.