### PR TITLE
Fixing 'output array is read-only' bug in LightRay

### DIFF
--- a/trident/light_ray.py
+++ b/trident/light_ray.py
@@ -470,27 +470,27 @@ class LightRay(CosmologySplice):
 
         assumed_units = "code_length"
         if left_edge is None:
-            left_edge = domain.domain_left_edge
+            left_edge = domain.domain_left_edge.copy()
         elif not hasattr(left_edge, 'units'):
             left_edge = domain.arr(left_edge, assumed_units)
         left_edge.convert_to_units('unitary')
 
         if right_edge is None:
-            right_edge = domain.domain_right_edge
+            right_edge = domain.domain_right_edge.copy()
         elif not hasattr(right_edge, 'units'):
             right_edge = domain.arr(right_edge, assumed_units)
         right_edge.convert_to_units('unitary')
 
         if start_position is not None:
             if hasattr(start_position, 'units'):
-                start_position = start_position
+                start_position = start_position.copy()
             else:
                 start_position = self.ds.arr(start_position, assumed_units)
             start_position.convert_to_units('unitary')
 
         if end_position is not None:
             if hasattr(end_position, 'units'):
-                end_position = end_position
+                end_position = end_position.copy()
             else:
                 end_position = self.ds.arr(end_position, assumed_units)
             end_position.convert_to_units('unitary')


### PR DESCRIPTION
A change in yt (https://github.com/yt-project/yt/pull/4641) last fall made certain attribute arrays immutable, which had the effect of breaking the `LightRay` class.  It also broke the `verify()` function which users are advised to run after the basic installation of Trident (see: https://trident.readthedocs.io/en/latest/installation.html#step-3-get-ionization-table-and-verify-installation).  Essentially, when the user tries to generate a `LightRay`, Trident tries to convert the unit system of the `start_position` and `end_position` to unitary, and yt yells because these are now immutable objects with the error:

```ValueError: output array is read-only```

This change corrects this problem in `LightRay` by making copies of the input arrays, which can then be modified as originally.  It is unclear to me why this didn't break the trident automated testing, as the `verify()` command is in the testing suite.
