### PR TITLE
Add "calculate_ion_fraction" function

### DIFF
--- a/tests/test_ion_balance.py
+++ b/tests/test_ion_balance.py
@@ -16,7 +16,8 @@ from trident.ion_balance import \
     add_ion_number_density_field, \
     add_ion_density_field, \
     add_ion_mass_field, \
-    add_ion_fields
+    add_ion_fields, \
+    calculate_ion_fraction
 from yt import \
     load, \
     SlicePlot
@@ -330,4 +331,23 @@ def test_to_not_overwrite_fields_for_particle():
     val_gas_after = ds.r[('gas', 'H_p0_number_density')][0]
     assert val_sph_before == val_sph_after
     assert val_gas_before == val_gas_after
+
+def test_calculate_ion_fraction():
+    """
+    Test to ensure calculate_ion_fraction() works
+    """
+    temp = np.logspace(4, 7, 100)
+    dens = np.ones_like(temp) * 1e-2
+    reds = np.ones_like(temp) * 0.25
+    # Does it work for arrays?
+    calculate_ion_fraction('H I', dens, temp, reds)
+
+    # Does it work for single values?
+    calculate_ion_fraction('Mg II', dens[0], temp[0], reds[0])
+
+    # Does it work for other ions?
+    calculate_ion_fraction('O VI', dens[0], temp[0], reds[0])
+
+    # Does it return all hydrogen being ionized at 1e7 K?
+    assert calculate_ion_fraction('H II', 1e-2, 1e7, 0) == 1
 

--- a/trident/__init__.py
+++ b/trident/__init__.py
@@ -36,7 +36,8 @@ from trident.ion_balance import \
     add_ion_density_field, \
     add_ion_mass_field, \
     solar_abundance, \
-    atomic_mass
+    atomic_mass, \
+    calculate_ion_fraction
 
 from trident.instrument import \
     Instrument

--- a/trident/ion_balance.py
+++ b/trident/ion_balance.py
@@ -956,7 +956,9 @@ def calculate_ion_fraction(ion, density, temperature, redshift, ionization_table
     fraction = np.clip(fraction, 0.0, 1.0)
     return fraction
 
+
 # Taken from Cloudy documentation.
+
 solar_abundance = {
     'H' : 1.00e+00, 'He': 1.00e-01, 'Li': 2.04e-09,
     'Be': 2.63e-11, 'B' : 6.17e-10, 'C' : 2.45e-04,

--- a/trident/ion_balance.py
+++ b/trident/ion_balance.py
@@ -871,9 +871,14 @@ def calculate_ion_fraction(ion, density, temperature, redshift, ionization_table
     This simple function interpolates ion fraction values from the relevant
     ion_balance data table for arrays of density, temperature, and redshift values.
 
+    Users can specify individual coordinates in density, temperature, and redshift
+    or N-sized arrays to derived values in parallel.
+
     Ion fractions are calculated assuming collisional ionization and
     photoionization in the optically thin limit from a redshift-dependent
     metagalactic ionizing background using the ionization_table specified.
+
+    Trilinear interpolation is assumed across density, temperature, and redshift.
 
     **Parameters**
 

--- a/trident/ion_balance.py
+++ b/trident/ion_balance.py
@@ -866,7 +866,50 @@ def _alias_field(ds, alias_name, name):
 
 def calculate_ion_fraction(ion, density, temperature, redshift, ionization_table=None):
     """
-    """
+    Calculate ion fraction at specified density, temperature, and redshift
+
+    This simple function interpolates ion fraction values from the relevant
+    ion_balance data table for arrays of density, temperature, and redshift values.
+
+    Ion fractions are calculated assuming collisional ionization and
+    photoionization in the optically thin limit from a redshift-dependent
+    metagalactic ionizing background using the ionization_table specified.
+
+    **Parameters**
+
+    :ion: string
+
+            The desired ion following the form: "<element> <ionization_state>"
+            Examples: "H I", "C II", "Mg II"
+
+    :density: float or array of floats
+
+            Gas density in the form of hydrogen number density cm$**{-3}$
+
+    :temperature: float or array of floats
+
+            Gas temperature in kelvin
+
+    :redshift: float or array of floats
+
+            Redshift at which to assume the metagalactic UV background
+
+    :ionization_table: string, optional
+
+        Path to an appropriately formatted HDF5 table that can be used to
+        compute the ion fraction as a function of density, temperature,
+        metallicity, and redshift.  When set to None, it uses the table
+        specified in ~/.trident/config
+        Default: None
+
+    **Example**
+
+    To calculate the ion fraction of Mg II for gas with hydrogen number
+    density 1e-2 cm**-3 and redshift 0.25 and temperatures 1e4K:
+
+    >>> import trident
+    >>> trident.calculate_ion_fraction('Mg II', 1e-2, 1e4, 0.25)
+"""
     if ionization_table is None:
         ionization_table = ion_table_filepath
 

--- a/trident/ion_balance.py
+++ b/trident/ion_balance.py
@@ -864,6 +864,7 @@ def _alias_field(ds, alias_name, name):
         ds.derived_field_list.append(alias_name)
     return
 
+
 def calculate_ion_fraction(ion, density, temperature, redshift, ionization_table=None):
     """
     Calculate ion fraction at specified density, temperature, and redshift


### PR DESCRIPTION
This PR adds a simple function to Trident for interpolating across the ion_balance files to return a value (or array of values) of ion fractions given coordinates in density, temperature, and redshift provided.  Previously, trident would only calculate this by creating a derived field on an input dataset, but it turns out that people just want to get the values out directly.  Particularly, this is useful for analytic and semi-analytic models to calculate these values on the fly.