### PR TITLE
Updating to version 2 of readthedocs.yml

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,5 +1,19 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+
+sphinx:
+  configuration: doc/source/conf.py
+
 python:
-   setup_py_install: false
-   pip_install: true
-   extra_requirements:
-        - dev
+  install:
+  - method: pip
+    path: .
+    extra_requirements:
+      - dev


### PR DESCRIPTION
Readthedocs has changed their configuration files since our last trident docs change, so we must thus change with the times.  Hopefully this addresses the problem, so that the new docs get built appropriately.