### PR TITLE
Allow option for empty rays to not raise errors

### DIFF
--- a/tests/test_ray_generator.py
+++ b/tests/test_ray_generator.py
@@ -29,6 +29,8 @@ COSMO_PLUS_SINGLE = os.path.join(answer_test_data_dir,
                                  "enzo_cosmology_plus/RD0009/RD0009")
 GIZMO_COSMO_SINGLE = os.path.join(answer_test_data_dir,
                                  "gizmo_cosmology_plus/snap_N128L16_150.hdf5")
+GIZMO_SINGLE = os.path.join(answer_test_data_dir,
+                            "FIRE_M12i_ref11/snapshot_600.hdf5")
 
 def test_create_simple_grid_ray_with_lines():
     """
@@ -88,3 +90,17 @@ def test_make_compound_ray_grid():
                                 fields=[('gas', 'temperature'),
                                         ('gas', 'metallicity')],
                                 data_filename=filename)
+
+def test_fail_empty():
+    """
+    During the creation of a simple ray test the fail_empty = False condition
+    """
+
+    dirpath = tempfile.mkdtemp()
+    filename = os.path.join(dirpath, 'ray.h5')
+    ds = load(GIZMO_SINGLE)
+    epsilon = ds.arr([1, 1, 1], 'kpc')
+    ray = tri.make_simple_ray(ds, start_position=ds.domain_right_edge,
+                              end_position=ds.domain_right_edge-epsilon,
+                              data_filename=filename, fail_empty=False,
+                              lines=['Mg'])

--- a/tests/test_ray_generator.py
+++ b/tests/test_ray_generator.py
@@ -15,6 +15,20 @@ import trident as tri
 import tempfile
 import shutil
 import os
+from yt.loaders import \
+    load
+from trident import \
+    LightRay, \
+    make_simple_ray
+from trident.testing import \
+    answer_test_data_dir
+
+COSMO_PLUS = os.path.join(answer_test_data_dir,
+                          "enzo_cosmology_plus/AMRCosmology.enzo")
+COSMO_PLUS_SINGLE = os.path.join(answer_test_data_dir,
+                                 "enzo_cosmology_plus/RD0009/RD0009")
+GIZMO_COSMO_SINGLE = os.path.join(answer_test_data_dir,
+                                 "gizmo_cosmology_plus/snap_N128L16_150.hdf5")
 
 def test_create_simple_grid_ray_with_lines():
     """
@@ -33,3 +47,44 @@ def test_create_simple_grid_ray_with_lines():
     sg.make_spectrum(ray, lines=['H', 'C IV'])
     sg.plot_spectrum(os.path.join(dirpath, 'spec.png'))
     shutil.rmtree(dirpath)
+
+def test_make_simple_ray_part():
+    """
+    Test the creation of a simple ray with default parameters for particle-
+    based dataset
+    """
+
+    dirpath = tempfile.mkdtemp()
+    filename = os.path.join(dirpath, 'ray.h5')
+    ds = load(GIZMO_COSMO_SINGLE)
+    ray = tri.make_simple_ray(ds, start_position=ds.domain_left_edge,
+                              end_position=ds.domain_right_edge,
+                              data_filename=filename,
+                              lines=['Mg'])
+
+def test_make_simple_ray_grid():
+    """
+    Test the creation of a simple ray with default parameters for grid-based
+    dataset
+    """
+
+    dirpath = tempfile.mkdtemp()
+    filename = os.path.join(dirpath, 'ray.h5')
+    ds = load(COSMO_PLUS_SINGLE)
+    ray = tri.make_simple_ray(ds, start_position=ds.domain_left_edge,
+                              end_position=ds.domain_right_edge,
+                              data_filename=filename,
+                              lines=['Mg'])
+
+def test_make_compound_ray_grid():
+    """
+    Test the creation of a compound ray with default parameters for grid-based
+    dataset
+    """
+
+    dirpath = tempfile.mkdtemp()
+    filename = os.path.join(dirpath, 'ray.h5')
+    ray = tri.make_compound_ray(COSMO_PLUS, 'Enzo', 0.0, 0.03, lines=['O'],
+                                fields=[('gas', 'temperature'),
+                                        ('gas', 'metallicity')],
+                                data_filename=filename)

--- a/trident/light_ray.py
+++ b/trident/light_ray.py
@@ -37,8 +37,6 @@ from yt.utilities.physical_constants import \
     speed_of_light_cgs
 from yt.data_objects.static_output import \
     Dataset
-from warnings import \
-    warn
 
 class LightRay(CosmologySplice):
     r"""
@@ -318,7 +316,7 @@ class LightRay(CosmologySplice):
                        solution_filename=None, data_filename=None,
                        get_los_velocity=None, use_peculiar_velocity=True,
                        redshift=None, field_parameters=None,
-                       empty_ray_fail=True, njobs=-1):
+                       fail_empty=True, njobs=-1):
         """
         Actually generate the LightRay by traversing the desired dataset.
 
@@ -431,7 +429,7 @@ class LightRay(CosmologySplice):
             accordingly.
             Default: None.
 
-        :empty_ray_fail: optional, bool
+        :fail_empty: optional, bool
 
             If True, Trident will fail when it tries to create a Ray
             that does not pass through any valud fluid elements. When
@@ -737,7 +735,7 @@ class LightRay(CosmologySplice):
 
         if data_filename is not None:
             self._write_light_ray(data_filename, all_data,
-                                  empty_ray_fail=empty_ray_fail)
+                                  fail_empty=fail_empty)
             ray_ds = YTDataLightRayDataset(data_filename)
 
             # temporary fix for yt-4.0 ytdata selection issue
@@ -752,7 +750,7 @@ class LightRay(CosmologySplice):
         return self._data[field]
 
     @parallel_root_only
-    def _write_light_ray(self, filename, data, empty_ray_fail=True):
+    def _write_light_ray(self, filename, data, fail_empty=True):
         """
         _write_light_ray(filename, data)
 
@@ -809,12 +807,12 @@ class LightRay(CosmologySplice):
         if 'temperature' in data or ('gas', 'temperature') in data:
             mask = data[f] > 0
             if not np.any(mask):
-                err = "No zones along light ray with nonzero %s. " \
-                      "Please modify your light ray trajectory." % (f,)
-                if empty_ray_fail:
+                err = "No zones along ray with nonzero %s. " \
+                      "Modify your ray trajectory." % (f,)
+                if fail_empty:
                     raise RuntimeError(err)
                 else:
-                    warn(err)
+                    mylog.warning(err)
             for key in data.keys():
                 data[key] = data[key][mask]
         save_as_dataset(ds, filename, data, field_types=field_types,

--- a/trident/light_ray.py
+++ b/trident/light_ray.py
@@ -37,6 +37,8 @@ from yt.utilities.physical_constants import \
     speed_of_light_cgs
 from yt.data_objects.static_output import \
     Dataset
+from warnings import \
+    warn
 
 class LightRay(CosmologySplice):
     r"""
@@ -315,7 +317,8 @@ class LightRay(CosmologySplice):
                        fields=None, setup_function=None,
                        solution_filename=None, data_filename=None,
                        get_los_velocity=None, use_peculiar_velocity=True,
-                       redshift=None, field_parameters=None, njobs=-1):
+                       redshift=None, field_parameters=None,
+                       empty_ray_fail=True, njobs=-1):
         """
         Actually generate the LightRay by traversing the desired dataset.
 
@@ -421,11 +424,19 @@ class LightRay(CosmologySplice):
             Default: None.
 
         :field_parameters: optional, dict
+
             Used to set field parameters in light rays. For example,
             if the 'bulk_velocity' field parameter is set, the relative
             velocities used to calculate peculiar velocity will be adjusted
             accordingly.
             Default: None.
+
+        :empty_ray_fail: optional, bool
+
+            If True, Trident will fail when it tries to create a Ray
+            that does not pass through any valud fluid elements. When
+            False, it will merely return a warning.
+            Default: True
 
         :njobs: optional, int
 
@@ -725,7 +736,8 @@ class LightRay(CosmologySplice):
         self._data = all_data
 
         if data_filename is not None:
-            self._write_light_ray(data_filename, all_data)
+            self._write_light_ray(data_filename, all_data,
+                                  empty_ray_fail=empty_ray_fail)
             ray_ds = YTDataLightRayDataset(data_filename)
 
             # temporary fix for yt-4.0 ytdata selection issue
@@ -740,7 +752,7 @@ class LightRay(CosmologySplice):
         return self._data[field]
 
     @parallel_root_only
-    def _write_light_ray(self, filename, data):
+    def _write_light_ray(self, filename, data, empty_ray_fail=True):
         """
         _write_light_ray(filename, data)
 
@@ -797,9 +809,12 @@ class LightRay(CosmologySplice):
         if 'temperature' in data or ('gas', 'temperature') in data:
             mask = data[f] > 0
             if not np.any(mask):
-                raise RuntimeError(
-                    "No zones along light ray with nonzero %s. "
-                    "Please modify your light ray trajectory." % (f,))
+                err = "No zones along light ray with nonzero %s. " \
+                      "Please modify your light ray trajectory." % (f,)
+                if empty_ray_fail:
+                    raise RuntimeError(err)
+                else:
+                    warn(err)
             for key in data.keys():
                 data[key] = data[key][mask]
         save_as_dataset(ds, filename, data, field_types=field_types,

--- a/trident/light_ray.py
+++ b/trident/light_ray.py
@@ -813,6 +813,7 @@ class LightRay(CosmologySplice):
                     raise RuntimeError(err)
                 else:
                     mylog.warning(err)
+                extra_attrs["empty"] = True
             for key in data.keys():
                 data[key] = data[key][mask]
         save_as_dataset(ds, filename, data, field_types=field_types,

--- a/trident/light_ray.py
+++ b/trident/light_ray.py
@@ -431,7 +431,7 @@ class LightRay(CosmologySplice):
 
         :fail_empty: optional, bool
 
-            If True, Trident will fail when it tries to create a Ray
+            If True, Trident will fail when it tries to create an empty Ray
             that does not pass through any valud fluid elements. When
             False, it will merely return a warning.
             Default: True

--- a/trident/ray_generator.py
+++ b/trident/ray_generator.py
@@ -32,7 +32,8 @@ def make_simple_ray(dataset_file, start_position, end_position,
                     solution_filename=None, data_filename=None,
                     trajectory=None, redshift=None, field_parameters=None,
                     setup_function=None, load_kwargs=None,
-                    line_database=None, ionization_table=None):
+                    line_database=None, ionization_table=None,
+                    empty_ray_fail=True):
     """
     Create a yt LightRay object for a single dataset (eg CGM).  This is a
     wrapper function around yt's LightRay interface to reduce some of the
@@ -68,7 +69,7 @@ def make_simple_ray(dataset_file, start_position, end_position,
     **Parameters**
 
     :dataset_file: string or yt Dataset object
-    
+
         Either a yt dataset or the filename of a dataset on disk.  If you are
         passing it a filename, consider usage of the ``load_kwargs`` and
         ``setup_function`` kwargs.
@@ -110,7 +111,7 @@ def make_simple_ray(dataset_file, start_position, end_position,
         Default: None
 
     :data_filename: string, optional
-    
+
         Output filename for ray data stored as an HDF5 file.  Note that
         at present, you *must* save a ray to disk in order for it to be
         returned by this function.  If set to None, defaults to 'ray.h5'.
@@ -231,7 +232,8 @@ def make_simple_ray(dataset_file, start_position, end_position,
                              solution_filename=solution_filename,
                              data_filename=data_filename,
                              field_parameters=field_parameters,
-                             redshift=redshift)
+                             redshift=redshift,
+                             empty_ray_fail=empty_ray_fail)
 
 def make_compound_ray(parameter_filename, simulation_type,
                       near_redshift, far_redshift,
@@ -284,7 +286,7 @@ def make_compound_ray(parameter_filename, simulation_type,
     in the dataset volume, the compound ray requires the near_redshift and
     far_redshift to determine which datasets to use to get full coverage
     in redshift space as the ray propagates from near_redshift to far_redshift.
-    
+
     Like the simple ray produced by :class:`~trident.make_simple_ray`,
     each gas cell intersected by the LightRay is sampled for the desired
     fields and stored.  Several additional fields are created and stored

--- a/trident/ray_generator.py
+++ b/trident/ray_generator.py
@@ -170,6 +170,13 @@ def make_simple_ray(dataset_file, start_position, end_position,
         it uses the table specified in ~/.trident/config
         Default: None
 
+    :fail_empty: optional, bool
+
+        If True, Trident will fail when it tries to create an empty Ray
+        that does not pass through any valud fluid elements. When
+        False, it will merely return a warning.
+        Default: True
+
     **Example**
 
     Generate a simple ray passing from the lower left corner to the upper
@@ -244,7 +251,8 @@ def make_compound_ray(parameter_filename, simulation_type,
                       find_outputs=False, seed=None,
                       setup_function=None, load_kwargs=None,
                       line_database=None, ionization_table=None,
-                      field_parameters = None):
+                      field_parameters = None,
+                      fail_empty=True):
     """
     Create a yt LightRay object for multiple consecutive datasets (eg IGM).
     This is a wrapper function around yt's LightRay interface to reduce some
@@ -441,6 +449,13 @@ def make_compound_ray(parameter_filename, simulation_type,
         accordingly.
         Default: None.
 
+    :fail_empty: optional, bool
+
+        If True, Trident will fail when it tries to create an empty Ray
+        that does not pass through any valud fluid elements. When
+        False, it will merely return a warning.
+        Default: True
+
     **Example**
 
     Generate a compound ray passing from the redshift 0 to redshift 0.05
@@ -519,7 +534,8 @@ def make_compound_ray(parameter_filename, simulation_type,
                              solution_filename=solution_filename,
                              data_filename=data_filename,
                              redshift=None, njobs=-1,
-                             field_parameters = field_parameters)
+                             field_parameters = field_parameters,
+                             fail_empty=fail_empty)
 
 def _determine_ions_from_lines(line_database, lines):
     """

--- a/trident/ray_generator.py
+++ b/trident/ray_generator.py
@@ -33,7 +33,7 @@ def make_simple_ray(dataset_file, start_position, end_position,
                     trajectory=None, redshift=None, field_parameters=None,
                     setup_function=None, load_kwargs=None,
                     line_database=None, ionization_table=None,
-                    empty_ray_fail=True):
+                    fail_empty=True):
     """
     Create a yt LightRay object for a single dataset (eg CGM).  This is a
     wrapper function around yt's LightRay interface to reduce some of the
@@ -233,7 +233,7 @@ def make_simple_ray(dataset_file, start_position, end_position,
                              data_filename=data_filename,
                              field_parameters=field_parameters,
                              redshift=redshift,
-                             empty_ray_fail=empty_ray_fail)
+                             fail_empty=fail_empty)
 
 def make_compound_ray(parameter_filename, simulation_type,
                       near_redshift, far_redshift,

--- a/trident/spectrum_generator.py
+++ b/trident/spectrum_generator.py
@@ -364,6 +364,9 @@ class SpectrumGenerator(AbsorptionSpectrum):
         if isinstance(ray, str):
             ray = load(ray)
         if isinstance(ray, Dataset):
+            if 'empty' in ray.parameters and ray.parameters['empty']:
+                mylog.warning("LightRay is empty. Not generating spectrum.")
+                return
             ad = ray.all_data()
         elif isinstance(ray, YTDataContainer):
             ad = ray


### PR DESCRIPTION
In some particle-based datasets, sometimes a ray trajectory may not pass through a fluid element.  The default behavior in this circumstance is for trident to raise an error and exit.  This PR adds the option to specify the keyword `fail_empty=False` when creating a `LightRay` that only raises a warning and creates an empty ray anyway.  Similarly, the `SpectrumGenerator` infrastructure was modified to not fail on empty `LightRay` objects, just to create a spectrum without any absorption and raise a warning.

This PR also adds docstrings for the new `fail_empty` keyword, as well as tests to the `LightRay` and `SpectrumGenerator` infrastructure to ensure this work.  The sample script demonstrates this functionality:

```
import yt
import trident
ds = yt.load_sample('FIRE_M12i_ref11')
ray_start = ds.domain_right_edge
ray_end = ds.domain_right_edge - ds.arr([1, 1, 1], 'kpc')
line_list = ['H', 'C', 'N', 'O', 'Mg']

ray = trident.make_simple_ray(ds, start_position=ray_start,
                              end_position=ray_end, data_filename='ray.h5',
                              lines=line_list, fail_empty=False)

sg = trident.SpectrumGenerator('COS')
sg.make_spectrum(ray, lines=line_list)
sg.plot_spectrum('spec_raw.png')
```