### PR TITLE
Updating to require python 3.10+

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -294,28 +294,28 @@ workflows:
    normal-tests:
      jobs:
        - tests:
-           name: "Python 3.9 tests with yt tip"
-           tag: "3.9.13"
-           yttag: "YT_HEAD"
-
-       - tests:
            name: "Python 3.10 tests with yt tip"
-           tag: "3.10.13"
+           tag: "3.10.15"
            yttag: "YT_HEAD"
            coverage: 1
 
        - tests:
            name: "Python 3.11 tests with yt tip"
-           tag: "3.11.4"
+           tag: "3.11.10"
            yttag: "YT_HEAD"
 
        - tests:
            name: "Python 3.11 tests with yt gold"
-           tag: "3.11.4"
+           tag: "3.11.10"
+
+       - tests:
+           name: "Python 3.12 tests with yt tip"
+           tag: "3.12.7"
+           yttag: "YT_HEAD"
 
        - docs-test:
            name: "Test docs build"
-           tag: "3.11.4"
+           tag: "3.11.10"
 
    weekly:
      triggers:
@@ -327,21 +327,27 @@ workflows:
                 - main
      jobs:
        - tests:
-           name: "Python 3.9 tests with yt gold"
-           tag: "3.9.13"
+           name: "Python 3.10 tests with yt gold"
+           tag: "3.10.15"
 
        - tests:
-           name: "Python 3.9 tests with yt tip"
-           tag: "3.9.13"
+           name: "Python 3.10 tests with yt tip"
+           tag: "3.10.15"
            yttag: "YT_HEAD"
            coverage: 0
 
        - tests:
            name: "Python 3.11 tests with yt tip"
-           tag: "3.11.4"
+           tag: "3.11.10"
+           yttag: "YT_HEAD"
+           coverage: 0
+
+       - tests:
+           name: "Python 3.12 tests with yt tip"
+           tag: "3.12.7"
            yttag: "YT_HEAD"
            coverage: 0
 
        - docs-test:
            name: "Test docs build"
-           tag: "3.11.4"
+           tag: "3.11.10"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -295,27 +295,27 @@ workflows:
      jobs:
        - tests:
            name: "Python 3.10 tests with yt tip"
-           tag: "3.10.15"
+           tag: "3.10.16"
            yttag: "YT_HEAD"
            coverage: 1
 
        - tests:
            name: "Python 3.11 tests with yt tip"
-           tag: "3.11.10"
+           tag: "3.11.11"
            yttag: "YT_HEAD"
 
        - tests:
            name: "Python 3.11 tests with yt gold"
-           tag: "3.11.10"
+           tag: "3.11.11"
 
        - tests:
            name: "Python 3.12 tests with yt tip"
-           tag: "3.12.7"
+           tag: "3.12.8"
            yttag: "YT_HEAD"
 
        - docs-test:
            name: "Test docs build"
-           tag: "3.11.10"
+           tag: "3.11.11"
 
    weekly:
      triggers:
@@ -328,26 +328,26 @@ workflows:
      jobs:
        - tests:
            name: "Python 3.10 tests with yt gold"
-           tag: "3.10.15"
+           tag: "3.10.16"
 
        - tests:
            name: "Python 3.10 tests with yt tip"
-           tag: "3.10.15"
+           tag: "3.10.16"
            yttag: "YT_HEAD"
            coverage: 0
 
        - tests:
            name: "Python 3.11 tests with yt tip"
-           tag: "3.11.10"
+           tag: "3.11.11"
            yttag: "YT_HEAD"
            coverage: 0
 
        - tests:
            name: "Python 3.12 tests with yt tip"
-           tag: "3.12.7"
+           tag: "3.12.8"
            yttag: "YT_HEAD"
            coverage: 0
 
        - docs-test:
            name: "Test docs build"
-           tag: "3.11.10"
+           tag: "3.11.11"

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
         'numpy',
         'requests',
         'scipy',
-        'yt>=4.0.1',
+        'yt>=4.4.0',
         'yt_astro_analysis>=1.1.0'],
       python_requires='>=3.10'
 )

--- a/setup.py
+++ b/setup.py
@@ -44,9 +44,9 @@ setup(
         "License :: OSI Approved :: BSD License",
         "Natural Language :: English",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: Scientific/Engineering :: Astronomy",
         "Topic :: Scientific/Engineering :: Physics",
         "Topic :: Scientific/Engineering :: Visualization",
@@ -63,5 +63,5 @@ setup(
         'scipy',
         'yt>=4.0.1',
         'yt_astro_analysis>=1.1.0'],
-      python_requires='>=3.9'
+      python_requires='>=3.10'
 )


### PR DESCRIPTION
Our primary dependency, yt, now requires 3.10, so we do too.  This also forces us to require yt 4.4 in order to work, since there were some relevant bugfixes in yt 4.4 dealing with `ProjectionPlot` and `ortho_ray` that change the values in Trident for `LightRay` and column_density calculations in some particle-based datasets.

https://github.com/yt-project/yt/pull/4783
https://github.com/yt-project/yt/pull/4939