### PR TITLE
Ensuring ion fields use species-specific metal fields when available for AREPO/Gadget datasets 

### DIFF
--- a/tests/test_ion_balance.py
+++ b/tests/test_ion_balance.py
@@ -17,7 +17,9 @@ from trident.ion_balance import \
     add_ion_density_field, \
     add_ion_mass_field, \
     add_ion_fields, \
-    calculate_ion_fraction
+    calculate_ion_fraction, \
+    atomic_mass, \
+    mh
 from yt import \
     load, \
     SlicePlot
@@ -351,3 +353,68 @@ def test_calculate_ion_fraction():
     # Does it return all hydrogen being ionized at 1e7 K?
     assert calculate_ion_fraction('H II', 1e-2, 1e7, 0) == 1
 
+def test_species_fraction_field_is_used_for_ion_mass_and_number_density():
+    """
+    Ensure Gadget/AREPO-style X_fraction fields are used in preference to the
+    bulk metallicity field when X_metallicity is absent.
+    """
+    ds = fake_random_ds(
+        8,
+        fields=("density", "temperature", "metallicity", "Mg_fraction"),
+        units=('g/cm**3', 'K', '', '')
+    )
+
+    ftype = ds.default_fluid_type
+
+    def _fixed_metallicity(field, data):
+        return data.ds.arr(
+            np.ones(data[(ftype, "density")].shape) * 1.0e-6, ""
+        )
+
+    def _fixed_mg_fraction(field, data):
+        return data.ds.arr(
+            np.ones(data[(ftype, "density")].shape) * 2.0e-2, ""
+        )
+
+    ds.add_field(
+        (ftype, "metallicity"),
+        function=_fixed_metallicity,
+        sampling_type="cell",
+        units="",
+        force_override=True,
+    )
+    ds.add_field(
+        (ftype, "Mg_fraction"),
+        function=_fixed_mg_fraction,
+        sampling_type="cell",
+        units="",
+        force_override=True,
+    )
+
+    ad = ds.all_data()
+
+    # Add the fields under test on the dataset's actual fluid type.
+    add_ion_fields(ds, ["Mg II"], ftype=ftype)
+
+    ion_frac = ad[(ftype, "Mg_p1_ion_fraction")]
+    ion_mass = ad[(ftype, "Mg_p1_mass")]
+    ion_ndens = ad[(ftype, "Mg_p1_number_density")]
+
+    density = ad[(ftype, "density")]
+    mass = ad[(ftype, "mass")]
+    mg_fraction = ad[(ftype, "Mg_fraction")]
+    bulk_metallicity = ad[(ftype, "metallicity")]
+
+    # The fixed code should use Mg_fraction.
+    expected_mass = ion_frac * mass * mg_fraction
+    expected_ndens = ion_frac * density * mg_fraction / (atomic_mass["Mg"] * mh)
+
+    assert_array_rel_equal(ion_mass, expected_mass, decimals=15)
+    assert_array_rel_equal(ion_ndens, expected_ndens, decimals=15)
+
+    # And specifically should not be using the bulk metallicity fallback.
+    wrong_mass = ion_frac * mass * bulk_metallicity
+    wrong_ndens = ion_frac * density * bulk_metallicity / (atomic_mass["Mg"] * mh)
+
+    assert not np.allclose(ion_mass, wrong_mass)
+    assert not np.allclose(ion_ndens, wrong_ndens)

--- a/trident/ion_balance.py
+++ b/trident/ion_balance.py
@@ -683,12 +683,19 @@ def _ion_mass(field, data):
         return data[ftype,fraction_field_name] * \
           data[ftype, nuclei_field]
 
-    # try the species metallicity
+    # try the species metallicity and fraction fields
+    # gizmo uses X_metallicity fields, AREPO+Gadget use X_fraction fields
+    # but they are intrinsically the same: mass fractions of total density field
     metallicity_field = "%s_metallicity" % atom
+    fraction_field = "%s_fraction" % atom
     if (ftype, metallicity_field) in data.ds.field_info:
         return data[ftype,fraction_field_name] * \
           data[ftype, "mass"] * \
           data[ftype, metallicity_field]
+    elif (ftype, fraction_field) in data.ds.field_info:
+        return data[ftype,fraction_field_name] * \
+          data[ftype, "mass"] * \
+          data[ftype, fraction_field]
 
     if atom == 'H' or atom == 'He':
         mass_fraction = solar_abundance[atom] * data[ftype,fraction_field_name]

--- a/trident/ion_balance.py
+++ b/trident/ion_balance.py
@@ -746,12 +746,20 @@ def _ion_number_density(field, data):
         return data[ftype, fraction_field_name] * \
           data[(ftype, nuclei_field)] / (atomic_mass[atom] * mh)
 
-    # try the species metallicity
+    # try the species metallicity and fraction fields
+    # gizmo uses X_metallicity fields, AREPO+Gadget use X_fraction fields
+    # but they are intrinsically the same: mass fractions of total density field
     metallicity_field = "%s_metallicity" % atom
+    fraction_field = "%s_fraction" % atom
     if (ftype, metallicity_field) in data.ds.field_info:
         return data[ftype, fraction_field_name] * \
           data[ftype, "density"] * \
           data[ftype, metallicity_field] / \
+          atomic_mass[atom] / mh
+    elif (ftype, fraction_field) in data.ds.field_info:
+        return data[ftype, fraction_field_name] * \
+          data[ftype, "density"] * \
+          data[ftype, fraction_field] / \
           atomic_mass[atom] / mh
 
     if atom == 'H' or atom == 'He':


### PR DESCRIPTION
As described in Issue #219, AREPO and Gadget datasets do not have `%s_metallicity` fields defined for datasets, but instead have `%s_fraction` fields defined.  Currently, Trident doesn't recognize these fields and instead just assumes solar abundances applied to the bulk level `metallicity` field.  This PR addresses that bug and now uses `%s_fraction` fields when defined on a dataset.  

This PR also includes a regression test to ensure this problem doesn't happen again.  Many thanks to @slucchini for helping track this down and test the fix.